### PR TITLE
Fix iVeri 3DS integration: ACS callback handler, PaRes forwarding, ECI correction

### DIFF
--- a/public-website/src/app/api/3ds/callback/route.ts
+++ b/public-website/src/app/api/3ds/callback/route.ts
@@ -1,0 +1,73 @@
+import { type NextRequest, NextResponse } from 'next/server';
+
+/**
+ * Next.js route handler for 3DS v1 ACS callback.
+ *
+ * The ACS (bank's authentication server) does a form POST to this URL after
+ * the cardholder completes the 3DS challenge. The POST body contains:
+ *   - PaRes: Payment Authentication Response (base64-encoded XML from ACS)
+ *   - MD:    Merchant Data — we set this to the merchant_reference
+ *
+ * We extract the merchant_reference and PaRes, then redirect the browser to
+ * the payment-status page (GET), carrying the data as query params so the
+ * page can forward PaRes to the Django backend for 3DS completion.
+ */
+export async function POST(request: NextRequest) {
+  let paRes = '';
+  let md = '';
+
+  const contentType = request.headers.get('content-type') ?? '';
+
+  if (contentType.includes('application/x-www-form-urlencoded') || contentType.includes('multipart/form-data')) {
+    try {
+      const formData = await request.formData();
+      paRes = (formData.get('PaRes') as string) ?? (formData.get('pares') as string) ?? '';
+      md = (formData.get('MD') as string) ?? (formData.get('md') as string) ?? '';
+    } catch {
+      // Fall through with empty values
+    }
+  } else {
+    try {
+      const text = await request.text();
+      const params = new URLSearchParams(text);
+      paRes = params.get('PaRes') ?? params.get('pares') ?? '';
+      md = params.get('MD') ?? params.get('md') ?? '';
+    } catch {
+      // Fall through with empty values
+    }
+  }
+
+  // MD is the merchant_reference we set when building the 3DS form
+  const merchantReference = md.trim();
+
+  // Build redirect URL for the payment-status page
+  const redirectUrl = new URL('/booking/payment-status', request.url);
+  redirectUrl.searchParams.set('channel', 'card');
+  if (merchantReference) {
+    redirectUrl.searchParams.set('ref', merchantReference);
+  }
+  if (paRes) {
+    // Encode PaRes so it survives as a query param (it's already base64 but may contain +/=)
+    redirectUrl.searchParams.set('pares', paRes);
+  }
+
+  return NextResponse.redirect(redirectUrl, { status: 303 });
+}
+
+// Some ACS implementations do a GET redirect instead of POST.
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const paRes = searchParams.get('PaRes') ?? searchParams.get('pares') ?? '';
+  const md = searchParams.get('MD') ?? searchParams.get('md') ?? '';
+
+  const redirectUrl = new URL('/booking/payment-status', request.url);
+  redirectUrl.searchParams.set('channel', 'card');
+  if (md) {
+    redirectUrl.searchParams.set('ref', md.trim());
+  }
+  if (paRes) {
+    redirectUrl.searchParams.set('pares', paRes);
+  }
+
+  return NextResponse.redirect(redirectUrl, { status: 303 });
+}

--- a/public-website/src/app/booking/payment-status/page.tsx
+++ b/public-website/src/app/booking/payment-status/page.tsx
@@ -60,6 +60,9 @@ function PaymentStatusPageContent() {
 
   const resourcePath = useMemo(() => searchParams.get('resourcePath') ?? '', [searchParams]);
 
+  // PaRes from the ACS callback (set by /api/3ds/callback route handler after ACS redirect)
+  const paRes = useMemo(() => searchParams.get('pares') ?? '', [searchParams]);
+
   const effectiveReference = useMemo(() => {
     const queryRef = searchParams.get('ref') ?? '';
     if (queryRef) {
@@ -123,7 +126,11 @@ function PaymentStatusPageContent() {
               headers: {
                 'Content-Type': 'application/json',
               },
-              body: JSON.stringify({ merchant_reference: reference }),
+              body: JSON.stringify({
+                merchant_reference: reference,
+                // Forward PaRes from ACS to backend for 3DS completion
+                ...(paRes ? { pares: paRes } : {}),
+              }),
             })
         : await fetch(`${API_BASE}/crm-api/payments/cbz/query/${reference}/`);
 
@@ -182,7 +189,7 @@ function PaymentStatusPageContent() {
       setStatus('failed');
       setMessage('Unable to reach payment services right now. Please try again.');
     }
-  }, [cardProvider, channel, effectiveReference, resourcePath]);
+  }, [cardProvider, channel, effectiveReference, paRes, resourcePath]);
 
   useEffect(() => {
     if (!effectiveReference && !resourcePath) {

--- a/public-website/src/components/BookingModal.tsx
+++ b/public-website/src/components/BookingModal.tsx
@@ -679,12 +679,19 @@ export default function BookingModal({
     }
 
     const paReq = challenge.PaReq || challenge.PAREQ || '';
-    const md = challenge.MD || merchantReference;
-    const termUrl = challenge.TermUrl || challenge.TermURL || `${window.location.origin}/booking/payment-status?channel=card${launchedFromWhatsApp ? `&source=whatsapp${activeBookingReference ? `&booking_reference=${encodeURIComponent(activeBookingReference)}` : ''}` : ''}`;
+    // MD is set to merchantReference so our callback route can extract it after ACS redirect
+    const md = merchantReference;
+    // TermUrl points to our API route handler so it can receive the ACS POST body (PaRes + MD)
+    // and then redirect to the payment-status page as a GET request.
+    const termUrl = `${window.location.origin}/api/3ds/callback`;
 
     setSessionItem(PENDING_3DS_REF_KEY, merchantReference);
+    setSessionItem(PENDING_PAYMENT_CHANNEL_KEY, 'card');
     if (activeBookingReference) {
       setSessionItem(PENDING_BOOKING_REFERENCE_KEY, activeBookingReference);
+    }
+    if (launchedFromWhatsApp) {
+      setSessionItem(RETURN_TO_WHATSAPP_KEY, '1');
     }
     setLastMerchantReference(merchantReference);
 

--- a/whatsappcrm_backend/cbz_integration/constants.py
+++ b/whatsappcrm_backend/cbz_integration/constants.py
@@ -33,8 +33,10 @@ COMMAND_LOOKUP = 'Lookup'
 MODE_TEST = 'Test'
 MODE_LIVE = 'LIVE'
 
-# ECI for e-commerce (Card Not Present)
-ECI_ECOMMERCE = '7'  # Secure e-commerce with SSL
+# ECI (Electronic Commerce Indicator) values
+ECI_ECOMMERCE = '7'           # Card Not Present, no 3DS authentication
+ECI_3DS_AUTHENTICATED = '5'   # Fully 3DS authenticated — liability shifts to issuer
+ECI_3DS_ATTEMPTED = '6'       # 3DS attempted but not completed (e.g. card not enrolled)
 
 # Result codes
 RESULT_CODE_SUCCESS = '0'

--- a/whatsappcrm_backend/cbz_integration/services.py
+++ b/whatsappcrm_backend/cbz_integration/services.py
@@ -29,6 +29,8 @@ from .constants import (
     COMMAND_LOOKUP,
     COMMAND_VOID,
     ECI_ECOMMERCE,
+    ECI_3DS_AUTHENTICATED,
+    ECI_3DS_ATTEMPTED,
     RESULT_CODE_SUCCESS,
     STATUS_PENDING,
     STATUS_APPROVED,
@@ -475,6 +477,55 @@ class IVeriClient:
         logger.info(
             "Card debit | pan=%s amount=%s %s ref=%s",
             masked, amount, currency, merchant_reference,
+        )
+
+        return self._execute(payload)
+
+    def complete_3ds_auth(
+        self,
+        transaction_index: str,
+        merchant_reference: str,
+        pares: str,
+        amount: Decimal,
+        currency: str,
+        authenticated: bool = True,
+    ) -> Dict[str, Any]:
+        """
+        Complete a 3DS v1 authentication by submitting PaRes to iVeri.
+
+        Called after the ACS redirects the browser back to the merchant's
+        TermUrl with PaRes in the POST body. Submits PaRes to iVeri to
+        finalize authentication and capture funds.
+
+        Args:
+            transaction_index: TransactionIndex from the original debit response
+            merchant_reference: Original merchant reference
+            pares: Payment Authentication Response from ACS (base64-encoded)
+            amount: Original transaction amount
+            currency: Currency code
+            authenticated: True if 3DS fully authenticated (ECI 5), False for attempted (ECI 6)
+
+        Returns:
+            iVeri API response dict
+        """
+        amount_cents = str(int(amount * 100))
+        eci = ECI_3DS_AUTHENTICATED if authenticated else ECI_3DS_ATTEMPTED
+
+        transaction_data = {
+            'Currency': currency,
+            'Amount': amount_cents,
+            'TransactionIndex': transaction_index,
+            'MerchantReference': merchant_reference,
+            'ECI': eci,
+            'ThreeDSecure': {
+                'PaRes': pares,
+            },
+        }
+
+        payload = self._build_payload(COMMAND_DEBIT, transaction_data)
+        logger.info(
+            "3DS complete | txn=%s ref=%s eci=%s pares_len=%d",
+            transaction_index, merchant_reference, eci, len(pares),
         )
 
         return self._execute(payload)

--- a/whatsappcrm_backend/cbz_integration/views.py
+++ b/whatsappcrm_backend/cbz_integration/views.py
@@ -1134,12 +1134,28 @@ def cbz_card_3ds_complete_view(request: HttpRequest) -> JsonResponse:
     if not merchant_reference:
         return JsonResponse({"success": False, "message": "Missing field: merchant_reference"}, status=400)
 
+    # PaRes is the bank ACS authentication response forwarded from the browser
+    pares = (payload.get('pares') or payload.get('PaRes') or '').strip()
+
     txn = CBZTransaction.objects.filter(
         merchant_reference=merchant_reference,
         payment_type=CBZTransaction.PaymentType.CARD,
     ).first()
     if not txn:
         return JsonResponse({"success": False, "message": "Transaction not found"}, status=404)
+
+    if pares:
+        logger.info(
+            "3DS PaRes received | ref=%s pares_len=%d",
+            merchant_reference, len(pares),
+        )
+        # Store PaRes in the transaction gateway response for audit
+        existing = txn.gateway_response or {}
+        if isinstance(existing, dict):
+            existing['_3ds_pares_received'] = True
+            existing['_3ds_pares_len'] = len(pares)
+            txn.gateway_response = existing
+            txn.save(update_fields=['gateway_response'])
 
     if txn.status == CBZTransaction.TransactionStatus.APPROVED:
         resolved_booking_reference = None
@@ -1158,7 +1174,34 @@ def cbz_card_3ds_complete_view(request: HttpRequest) -> JsonResponse:
 
     client = _build_client()
     try:
-        response = client.query_transaction(merchant_reference=merchant_reference)
+        # If PaRes and TransactionIndex are available, submit them to iVeri to
+        # complete the 3DS authentication. This is the proper 3DS v1 completion
+        # flow (liability shifts to the issuer on success).
+        if pares and txn.transaction_index:
+            logger.info(
+                "Submitting 3DS PaRes to iVeri | ref=%s txn_idx=%s",
+                merchant_reference, txn.transaction_index,
+            )
+            try:
+                response = client.complete_3ds_auth(
+                    transaction_index=txn.transaction_index,
+                    merchant_reference=merchant_reference,
+                    pares=pares,
+                    amount=txn.amount,
+                    currency=txn.currency,
+                )
+            except Exception:
+                logger.warning(
+                    "3DS PaRes submission failed, falling back to query | ref=%s",
+                    merchant_reference, exc_info=True,
+                )
+                response = client.query_transaction(merchant_reference=merchant_reference)
+        else:
+            # No PaRes or TransactionIndex — query current status.
+            # iVeri may have already updated the transaction via server-to-server
+            # notification from the ACS (requires NotificationURL to be configured).
+            response = client.query_transaction(merchant_reference=merchant_reference)
+
         result = IVeriClient.get_result(response)
         is_approved = IVeriClient.is_approved(response)
         is_pending = IVeriClient.is_pending(response)


### PR DESCRIPTION
## Summary

- **ACS POST handler**: Created `/api/3ds/callback` Next.js route to properly receive the form POST from the bank's ACS after 3DS challenge. Previously the TermUrl pointed to a client-side page that can't read POST body — PaRes was silently lost.
- **PaRes forwarding**: The callback handler redirects to the payment-status page with PaRes as a query param; the page forwards it to the Django backend's `/3ds/complete/` endpoint, which now submits PaRes to iVeri via a new `complete_3ds_auth()` method.
- **ECI correction**: Added `ECI_3DS_AUTHENTICATED = '5'` and `ECI_3DS_ATTEMPTED = '6'` constants. The 3DS completion now sends the correct ECI value for liability shift instead of the generic `'7'` (no 3DS).
- **Session state**: Fixed `PENDING_PAYMENT_CHANNEL_KEY` and `RETURN_TO_WHATSAPP_KEY` not being stored in sessionStorage before the ACS redirect.

## Test plan

- [ ] Card payment triggers 3DS challenge (check iVeri test card in Test mode)
- [ ] ACS challenge completes and redirects to `/booking/payment-status` via `/api/3ds/callback`
- [ ] Payment-status page shows "Approved" after 3DS completes successfully
- [ ] Backend logs show PaRes received and submitted to iVeri
- [ ] Non-3DS card payments still work (no regression)
- [ ] EcoCash payments unaffected

https://claude.ai/code/session_01GibyEVSi7efSMV6R587vPt

---
_Generated by [Claude Code](https://claude.ai/code/session_01GibyEVSi7efSMV6R587vPt)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added 3D Secure (3DS) authentication support for card payments, allowing customers to complete secure payment verification.
  * Enhanced payment status tracking to properly handle 3DS authentication results and complete transactions upon verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->