### PR TITLE
Remove Visa/Mastercard-only card type restriction

### DIFF
--- a/public-website/src/components/BookingModal.tsx
+++ b/public-website/src/components/BookingModal.tsx
@@ -922,7 +922,7 @@ export default function BookingModal({
         const checkoutUrl = new URL(`${window.location.origin}/booking/card-checkout`);
         checkoutUrl.searchParams.set('checkoutId', String(result.checkout_id));
         checkoutUrl.searchParams.set('merchantRef', merchantRef);
-        checkoutUrl.searchParams.set('brands', String(result.brands || 'VISA MASTER AMEX'));
+        checkoutUrl.searchParams.set('brands', String(result.brands || 'VISA MASTER AMEX ZIMSWITCH'));
         checkoutUrl.searchParams.set('widget', String(result.widget_script_url || ''));
         checkoutUrl.searchParams.set('returnUrl', resultUrl.toString());
         if (result.integrity) {
@@ -955,9 +955,8 @@ export default function BookingModal({
       setPaymentMessage('Card number failed validation. Please check and try again.');
       return;
     }
-    if (brand !== 'visa' && brand !== 'mastercard') {
-      setPaymentMessage('Only Visa and Mastercard are currently accepted on this checkout.');
-      return;
+    if (brand === 'unknown') {
+      // Don't block — let the gateway decline unsupported cards with a clear message
     }
     if (expiryDate.length !== 4) {
       setPaymentMessage('Enter expiry date in MM/YY format.');


### PR DESCRIPTION
## Summary

- Removes the frontend check that blocked all non-Visa/Mastercard cards from submitting on the `cbz_direct` provider
- Previously, AMEX, ZimSwitch, Diners, JCB, and any unrecognised card would hit "Only Visa and Mastercard are currently accepted" and never reach the gateway
- Now the gateway (iVeri/CBZ) handles brand rejection with a proper decline message — which is the right place for that check
- Fixes the `brands` fallback in `BookingModal` to include `ZIMSWITCH`

## Test plan

- [ ] Enter a ZimSwitch card number in the direct card form — it should submit (not be blocked at the UI level)
- [ ] Enter a completely invalid card number — still blocked by Luhn check
- [ ] Enter a Visa card — works as before
- [ ] Enter an AMEX card — now reaches the gateway instead of being rejected by the UI

https://claude.ai/code/session_01P2wCYVUWtni8XjH7T12xJ8

---
_Generated by [Claude Code](https://claude.ai/code/session_01P2wCYVUWtni8XjH7T12xJ8)_