### PR TITLE
Restore CVV requirement on COPYandPAY hosted checkout

### DIFF
--- a/public-website/src/app/about/page.tsx
+++ b/public-website/src/app/about/page.tsx
@@ -21,7 +21,7 @@ export default function AboutPage() {
         />
         <div className="absolute inset-0 bg-gradient-to-b from-black/60 via-black/40 to-black/70" />
         <div className="relative text-center text-white px-6">
-          <p className="text-sm uppercase tracking-[0.3em] text-[#ffba5a] font-semibold mb-3">
+          <p className="text-sm uppercase tracking-[0.3em] text-[#E09A18] font-semibold mb-3">
             Our Story
           </p>
           <h1 className="text-4xl md:text-6xl font-black drop-shadow-lg">
@@ -31,10 +31,10 @@ export default function AboutPage() {
       </section>
 
       {/* Main Content */}
-      <section className="py-20 bg-gradient-to-b from-white via-[#fff7ec] to-white relative overflow-hidden">
+      <section className="py-20 bg-gradient-to-b from-white via-[#FFF9F5] to-white relative overflow-hidden">
         <div className="absolute inset-0 pointer-events-none">
-          <div className="absolute top-10 left-10 w-48 h-48 bg-[#ffba5a]/15 blur-3xl rounded-full" />
-          <div className="absolute bottom-10 right-10 w-56 h-56 bg-[#ff9800]/10 blur-3xl rounded-full" />
+          <div className="absolute top-10 left-10 w-48 h-48 bg-[#E09A18]/15 blur-3xl rounded-full" />
+          <div className="absolute bottom-10 right-10 w-56 h-56 bg-[#E8600A]/10 blur-3xl rounded-full" />
         </div>
 
         <div className="container mx-auto px-6 relative">
@@ -43,7 +43,7 @@ export default function AboutPage() {
             <div className="bg-white/75 backdrop-blur-lg border border-white/60 shadow-xl rounded-2xl p-8 md:p-10 relative overflow-hidden">
               <div className="absolute inset-0 bg-gradient-to-br from-white/60 via-transparent to-white/30" />
               <h2 className="relative text-3xl md:text-4xl font-black text-gray-900 mb-6">
-                <span className="text-transparent bg-clip-text bg-gradient-to-r from-[#ff9800] to-[#ffba5a]">Kalai</span> — The Cry of the Fish Eagle
+                <span className="text-transparent bg-clip-text bg-gradient-to-r from-[#E8600A] to-[#E09A18]">Kalai</span> — The Cry of the Fish Eagle
               </h2>
               <p className="relative text-lg text-gray-700 leading-relaxed mb-4">
                 Kalai Safaris is a boating safari company on the mighty Zambezi River, above the Victoria Falls. We are dedicated to providing unforgettable cruise experiences that combine the beauty of Africa&apos;s wildlife with the serenity of the river.
@@ -84,19 +84,19 @@ export default function AboutPage() {
               </p>
               <ul className="relative space-y-3 text-gray-700">
                 <li className="flex items-start gap-3">
-                  <span className="w-2 h-2 rounded-full bg-[#ff9800] mt-2 flex-shrink-0" />
+                  <span className="w-2 h-2 rounded-full bg-[#E8600A] mt-2 flex-shrink-0" />
                   Expert guides with deep knowledge of the Zambezi ecosystem
                 </li>
                 <li className="flex items-start gap-3">
-                  <span className="w-2 h-2 rounded-full bg-[#ff9800] mt-2 flex-shrink-0" />
+                  <span className="w-2 h-2 rounded-full bg-[#E8600A] mt-2 flex-shrink-0" />
                   Safety-first approach with well-maintained vessels
                 </li>
                 <li className="flex items-start gap-3">
-                  <span className="w-2 h-2 rounded-full bg-[#ff9800] mt-2 flex-shrink-0" />
+                  <span className="w-2 h-2 rounded-full bg-[#E8600A] mt-2 flex-shrink-0" />
                   Tailor-made cruises for weddings, conferences & events
                 </li>
                 <li className="flex items-start gap-3">
-                  <span className="w-2 h-2 rounded-full bg-[#ff9800] mt-2 flex-shrink-0" />
+                  <span className="w-2 h-2 rounded-full bg-[#E8600A] mt-2 flex-shrink-0" />
                   Eco-friendly practices supporting conservation
                 </li>
               </ul>

--- a/public-website/src/app/booking/card-checkout/page-fixed.tsx
+++ b/public-website/src/app/booking/card-checkout/page-fixed.tsx
@@ -133,6 +133,7 @@ function setWpwlOptions(onWidgetError: (msg: string, expired: boolean) => void) 
       'card-number-placeholder': { color: '#9ca3af', fontSize: '15px', fontFamily: 'inherit' },
       'cvv-placeholder':         { color: '#9ca3af', fontSize: '15px', fontFamily: 'inherit' },
     },
+
     labels: {
       cardHolder:  'Name on Card',
       cardNumber:  'Card Number',

--- a/public-website/src/app/booking/card-checkout/page-fixed.tsx
+++ b/public-website/src/app/booking/card-checkout/page-fixed.tsx
@@ -133,7 +133,6 @@ function setWpwlOptions(onWidgetError: (msg: string, expired: boolean) => void) 
       'card-number-placeholder': { color: '#9ca3af', fontSize: '15px', fontFamily: 'inherit' },
       'cvv-placeholder':         { color: '#9ca3af', fontSize: '15px', fontFamily: 'inherit' },
     },
-
     labels: {
       cardHolder:  'Name on Card',
       cardNumber:  'Card Number',

--- a/public-website/src/app/booking/card-checkout/page-fixed.tsx
+++ b/public-website/src/app/booking/card-checkout/page-fixed.tsx
@@ -128,7 +128,6 @@ function setWpwlOptions(onWidgetError: (msg: string, expired: boolean) => void) 
   // Must be set on window BEFORE the paymentWidgets.js script loads
   (window as Window & { wpwlOptions?: object }).wpwlOptions = {
     style: 'plain',
-    requireCvv: false,
     iframeStyles: {
       'card-number-placeholder': { color: '#9ca3af', fontSize: '15px', fontFamily: 'inherit' },
       'cvv-placeholder':         { color: '#9ca3af', fontSize: '15px', fontFamily: 'inherit' },

--- a/public-website/src/app/booking/card-checkout/page.tsx
+++ b/public-website/src/app/booking/card-checkout/page.tsx
@@ -133,6 +133,7 @@ function setWpwlOptions(onWidgetError: (msg: string, expired: boolean) => void) 
       'card-number-placeholder': { color: '#9ca3af', fontSize: '15px', fontFamily: 'inherit' },
       'cvv-placeholder':         { color: '#9ca3af', fontSize: '15px', fontFamily: 'inherit' },
     },
+
     labels: {
       cardHolder:  'Name on Card',
       cardNumber:  'Card Number',

--- a/public-website/src/app/booking/card-checkout/page.tsx
+++ b/public-website/src/app/booking/card-checkout/page.tsx
@@ -133,7 +133,6 @@ function setWpwlOptions(onWidgetError: (msg: string, expired: boolean) => void) 
       'card-number-placeholder': { color: '#9ca3af', fontSize: '15px', fontFamily: 'inherit' },
       'cvv-placeholder':         { color: '#9ca3af', fontSize: '15px', fontFamily: 'inherit' },
     },
-
     labels: {
       cardHolder:  'Name on Card',
       cardNumber:  'Card Number',

--- a/public-website/src/app/booking/card-checkout/page.tsx
+++ b/public-website/src/app/booking/card-checkout/page.tsx
@@ -128,7 +128,6 @@ function setWpwlOptions(onWidgetError: (msg: string, expired: boolean) => void) 
   // Must be set on window BEFORE the paymentWidgets.js script loads
   (window as Window & { wpwlOptions?: object }).wpwlOptions = {
     style: 'plain',
-    requireCvv: false,
     iframeStyles: {
       'card-number-placeholder': { color: '#9ca3af', fontSize: '15px', fontFamily: 'inherit' },
       'cvv-placeholder':         { color: '#9ca3af', fontSize: '15px', fontFamily: 'inherit' },

--- a/public-website/src/app/booking/page.tsx
+++ b/public-website/src/app/booking/page.tsx
@@ -57,8 +57,11 @@ const cruises = [
   },
 ];
 
+type PageStep = 'select' | 'booking';
+
 function BookingPageContent() {
   const searchParams = useSearchParams();
+  const [pageStep, setPageStep] = useState<PageStep>('select');
   const [selectedCruise, setSelectedCruise] = useState(cruises[0].title);
   const [selectedAmountUsd, setSelectedAmountUsd] = useState(cruises[0].amountUsd);
   const [isPaymentScreen, setIsPaymentScreen] = useState(false);
@@ -73,10 +76,10 @@ function BookingPageContent() {
     return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
   }, [searchParams]);
 
+  // Deep-links from WhatsApp or from cruise cards on other pages skip straight to booking form
   useEffect(() => {
-    if (!queryBookingReference && queryPaymentMode !== 'card') {
-      return;
-    }
+    const isDeepLink = Boolean(queryBookingReference) || queryPaymentMode === 'card' || Boolean(queryTourName) || querySource === 'whatsapp';
+    if (!isDeepLink) return;
 
     const id = window.setTimeout(() => {
       if (queryTourName) {
@@ -84,11 +87,10 @@ function BookingPageContent() {
       } else if (querySource === 'whatsapp') {
         setSelectedCruise('WhatsApp Booking');
       }
-
       if (queryAmountUsd !== null) {
         setSelectedAmountUsd(queryAmountUsd);
       }
-
+      setPageStep('booking');
     }, 0);
 
     return () => window.clearTimeout(id);
@@ -97,178 +99,167 @@ function BookingPageContent() {
   const handleBookClick = (cruiseTitle: string, amountUsd: number) => {
     setSelectedCruise(cruiseTitle);
     setSelectedAmountUsd(amountUsd);
-
-    window.setTimeout(() => {
-      document.getElementById('booking-flow')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    }, 0);
+    setPageStep('booking');
+    window.scrollTo({ top: 0, behavior: 'smooth' });
   };
 
-  return (
-    <div className="min-h-screen">
-      {!isPaymentScreen && (
-      <>
-      {/* Hero Banner */}
-      <section className="relative h-[40vh] md:h-[50vh] flex items-center justify-center overflow-hidden">
-        <Image
-          src="/images/slider/1.jpeg"
-          alt="Zambezi River Cruise"
-          fill
-          className="object-cover"
-          priority
-        />
-        <div className="absolute inset-0 bg-gradient-to-b from-black/60 via-black/40 to-black/70" />
-        <div className="relative text-center text-white px-6">
-          <p className="text-sm uppercase tracking-[0.3em] text-[#E09A18] font-semibold mb-3">
-            Reservations
-          </p>
-          <h1 className="text-4xl md:text-6xl font-black drop-shadow-lg mb-4">
-            Book Your Safari Cruise
-          </h1>
-          <p className="text-lg md:text-xl text-white/80 max-w-2xl mx-auto">
-            Choose your perfect Zambezi experience and we&apos;ll handle the rest
-          </p>
-        </div>
-      </section>
+  const handleBackToSelect = () => {
+    setPageStep('select');
+    setIsPaymentScreen(false);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
 
-      {/* Cruise Selection Cards */}
-      <section className="py-20 bg-gradient-to-b from-white via-[#FFF9F5] to-white relative overflow-hidden">
-        <div className="absolute inset-0 pointer-events-none">
-          <div className="absolute top-10 left-10 w-48 h-48 bg-[#E09A18]/15 blur-3xl rounded-full" />
-          <div className="absolute bottom-10 right-10 w-56 h-56 bg-[#E8600A]/10 blur-3xl rounded-full" />
-        </div>
-
-        <div className="container mx-auto px-6 relative">
-          <div className="text-center mb-14">
-            <p className="text-sm uppercase tracking-[0.3em] text-[#E8600A] font-semibold mb-3">
-              Choose Your Cruise
+  // ── Step 1: Cruise Selection ──────────────────────────────────────────────
+  if (pageStep === 'select') {
+    return (
+      <div className="min-h-screen">
+        {/* Hero Banner */}
+        <section className="relative h-[40vh] md:h-[50vh] flex items-center justify-center overflow-hidden">
+          <Image
+            src="/images/slider/1.jpeg"
+            alt="Zambezi River Cruise"
+            fill
+            className="object-cover"
+            priority
+          />
+          <div className="absolute inset-0 bg-gradient-to-b from-black/60 via-black/40 to-black/70" />
+          <div className="relative text-center text-white px-6">
+            <p className="text-sm uppercase tracking-[0.3em] text-[#E09A18] font-semibold mb-3">
+              Step 1 of 3
             </p>
-            <h2 className="text-3xl md:text-4xl font-black text-gray-900 mb-4">
-              Select a Cruise to Book
-            </h2>
-            <p className="text-gray-600 max-w-xl mx-auto">
-              Pick your preferred cruise type and time. We&apos;ll confirm availability on WhatsApp.
+            <h1 className="text-4xl md:text-6xl font-black drop-shadow-lg mb-4">
+              Choose Your Cruise
+            </h1>
+            <p className="text-lg md:text-xl text-white/80 max-w-2xl mx-auto">
+              Pick your perfect Zambezi experience to get started
             </p>
           </div>
+        </section>
 
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-12">
-            {cruises.map((cruise, index) => (
-              <div
-                key={index}
-                className="group relative bg-white/80 backdrop-blur-lg border border-white/60 shadow-lg rounded-2xl overflow-hidden transition-all duration-300 hover:-translate-y-2 hover:shadow-2xl"
-              >
-                {/* Cruise Image */}
-                <div className="relative h-48 overflow-hidden">
-                  <Image
-                    src={cruise.image}
-                    alt={cruise.title}
-                    fill
-                    className="object-cover group-hover:scale-110 transition-transform duration-500"
-                  />
-                  <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent" />
-                  <div className="absolute bottom-3 left-3">
-                    <span className="inline-flex items-center gap-1 px-3 py-1 rounded-full text-xs font-bold bg-gradient-to-r from-[#C8102E] to-[#E8600A] text-black shadow-sm">
-                      <cruise.Icon size={12} /> {cruise.price}
-                    </span>
+        {/* Step indicator */}
+        <div className="bg-white border-b border-gray-100 sticky top-0 z-10">
+          <div className="container mx-auto px-6 py-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.12em]">
+            <span className="rounded-full bg-[#C8102E] text-white px-3 py-1">1. Choose Cruise</span>
+            <span className="text-gray-300">›</span>
+            <span className="rounded-full bg-gray-100 text-gray-400 px-3 py-1">2. Your Details</span>
+            <span className="text-gray-300">›</span>
+            <span className="rounded-full bg-gray-100 text-gray-400 px-3 py-1">3. Payment</span>
+          </div>
+        </div>
+
+        {/* Cruise Selection Cards */}
+        <section className="py-16 bg-gradient-to-b from-white via-[#FFF9F5] to-white relative overflow-hidden">
+          <div className="absolute inset-0 pointer-events-none">
+            <div className="absolute top-10 left-10 w-48 h-48 bg-[#E09A18]/15 blur-3xl rounded-full" />
+            <div className="absolute bottom-10 right-10 w-56 h-56 bg-[#E8600A]/10 blur-3xl rounded-full" />
+          </div>
+
+          <div className="container mx-auto px-6 relative">
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-12">
+              {cruises.map((cruise, index) => (
+                <div
+                  key={index}
+                  className="group relative bg-white/80 backdrop-blur-lg border border-white/60 shadow-lg rounded-2xl overflow-hidden transition-all duration-300 hover:-translate-y-2 hover:shadow-2xl"
+                >
+                  <div className="relative h-48 overflow-hidden">
+                    <Image
+                      src={cruise.image}
+                      alt={cruise.title}
+                      fill
+                      className="object-cover group-hover:scale-110 transition-transform duration-500"
+                    />
+                    <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent" />
+                    <div className="absolute bottom-3 left-3">
+                      <span className="inline-flex items-center gap-1 px-3 py-1 rounded-full text-xs font-bold bg-gradient-to-r from-[#C8102E] to-[#E8600A] text-white shadow-sm">
+                        <cruise.Icon size={12} /> {cruise.price}
+                      </span>
+                    </div>
+                  </div>
+
+                  <div className="p-5">
+                    <h3 className="text-xl font-bold text-gray-900 mb-1">{cruise.title}</h3>
+                    <p className="text-sm text-[#E8600A] font-medium mb-3">{cruise.time}</p>
+                    <p className="text-gray-600 text-sm leading-relaxed mb-4">{cruise.description}</p>
+                    <button
+                      onClick={() => handleBookClick(cruise.title, cruise.amountUsd)}
+                      className="w-full rounded-full bg-gradient-to-r from-[#C8102E] to-[#E8600A] hover:from-[#E8173A] hover:to-[#F47B1A] text-white font-bold py-2.5 transition-all duration-300 shadow-md hover:shadow-xl hover:-translate-y-0.5"
+                    >
+                      Book This Cruise →
+                    </button>
                   </div>
                 </div>
+              ))}
+            </div>
 
-                {/* Card Content */}
-                <div className="p-5">
-                  <h3 className="text-xl font-bold text-gray-900 mb-1">{cruise.title}</h3>
-                  <p className="text-sm text-[#E8600A] font-medium mb-3">{cruise.time}</p>
-                  <p className="text-gray-600 text-sm leading-relaxed mb-4">{cruise.description}</p>
-                  <button
-                    onClick={() => handleBookClick(cruise.title, cruise.amountUsd)}
-                    className="w-full rounded-full bg-gradient-to-r from-[#C8102E] to-[#E8600A] hover:from-[#E8173A] hover:to-[#F47B1A] text-black font-bold py-2.5 transition-all duration-300 shadow-md hover:shadow-xl hover:-translate-y-0.5"
+            {/* Contact Methods */}
+            <div className="max-w-3xl mx-auto">
+              <div className="bg-white/75 backdrop-blur-lg border border-white/60 shadow-xl rounded-2xl p-8 relative overflow-hidden">
+                <div className="absolute inset-0 bg-gradient-to-br from-white/60 via-transparent to-white/30" />
+                <h3 className="relative text-xl font-bold text-gray-900 mb-5 text-center">
+                  Prefer to book directly?
+                </h3>
+                <div className="relative grid grid-cols-1 md:grid-cols-3 gap-4">
+                  <a
+                    href="https://wa.me/263712629336?text=*[Message from Kalai Safaris Website]*%0A%0AHi, I'd like to book a cruise. Please help!"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center justify-center gap-3 p-4 rounded-xl bg-[#25D366]/10 border border-[#25D366]/20 hover:bg-[#25D366] hover:text-white text-[#25D366] transition-all duration-300 font-semibold"
                   >
-                    Book This Cruise
-                  </button>
+                    <FaWhatsapp size={22} />
+                    WhatsApp
+                  </a>
+                  <a
+                    href="tel:+263712629336"
+                    className="flex items-center justify-center gap-3 p-4 rounded-xl bg-[#E8600A]/10 border border-[#ff9800]/20 hover:bg-[#ff9800] hover:text-black text-[#E8600A] transition-all duration-300 font-semibold"
+                  >
+                    <FaPhone size={18} />
+                    +263 712 629 336
+                  </a>
+                  <a
+                    href="mailto:reservation@kalaisafaris.com"
+                    className="flex items-center justify-center gap-3 p-4 rounded-xl bg-[#0A0A0A]/10 border border-[#0A0A0A]/20 hover:bg-[#0A0A0A] hover:text-white text-[#0A0A0A] transition-all duration-300 font-semibold"
+                  >
+                    <FaEnvelope size={18} />
+                    Email Us
+                  </a>
                 </div>
               </div>
-            ))}
-          </div>
-
-          {/* Contact Methods */}
-          <div className="max-w-3xl mx-auto">
-            <div className="bg-white/75 backdrop-blur-lg border border-white/60 shadow-xl rounded-2xl p-8 relative overflow-hidden">
-              <div className="absolute inset-0 bg-gradient-to-br from-white/60 via-transparent to-white/30" />
-              <h3 className="relative text-2xl font-bold text-gray-900 mb-6 text-center">
-                Or Contact Us Directly
-              </h3>
-              <div className="relative grid grid-cols-1 md:grid-cols-3 gap-4">
-                <a
-                  href="https://wa.me/263712629336?text=*[Message from Kalai Safaris Website]*%0A%0AHi, I'd like to book a cruise. Please help!"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="flex items-center justify-center gap-3 p-4 rounded-xl bg-[#25D366]/10 border border-[#25D366]/20 hover:bg-[#25D366] hover:text-white text-[#25D366] transition-all duration-300 font-semibold"
-                >
-                  <FaWhatsapp size={22} />
-                  WhatsApp
-                </a>
-                <a
-                  href="tel:+263712629336"
-                  className="flex items-center justify-center gap-3 p-4 rounded-xl bg-[#E8600A]/10 border border-[#ff9800]/20 hover:bg-[#ff9800] hover:text-black text-[#E8600A] transition-all duration-300 font-semibold"
-                >
-                  <FaPhone size={18} />
-                  +263 712 629 336
-                </a>
-                <a
-                  href="mailto:reservation@kalaisafaris.com"
-                  className="flex items-center justify-center gap-3 p-4 rounded-xl bg-[#0A0A0A]/10 border border-[#0A0A0A]/20 hover:bg-[#0A0A0A] hover:text-white text-[#0A0A0A] transition-all duration-300 font-semibold"
-                >
-                  <FaEnvelope size={18} />
-                  Email Us
-                </a>
-              </div>
             </div>
           </div>
+        </section>
+
+        <FooterSection />
+      </div>
+    );
+  }
+
+  // ── Step 2 + 3: Booking Form (details → payment) ──────────────────────────
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-[#FFF9F5] via-white to-[#FFF9F5]">
+      {/* Step indicator */}
+      {!isPaymentScreen && (
+        <div className="bg-white border-b border-gray-100 sticky top-0 z-10">
+          <div className="container mx-auto px-6 py-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.12em]">
+            <button
+              onClick={handleBackToSelect}
+              className="rounded-full bg-gray-100 text-gray-500 hover:bg-gray-200 px-3 py-1 transition"
+            >
+              ← 1. Choose Cruise
+            </button>
+            <span className="text-gray-300">›</span>
+            <span className="rounded-full bg-[#C8102E] text-white px-3 py-1">2. Your Details</span>
+            <span className="text-gray-300">›</span>
+            <span className="rounded-full bg-gray-100 text-gray-400 px-3 py-1">3. Payment</span>
+          </div>
         </div>
-      </section>
-      </>
       )}
 
-      <section id="booking-flow" className={`${isPaymentScreen ? 'fixed inset-0 z-[120] overflow-y-auto bg-white py-6' : 'py-20 bg-gradient-to-b from-[#fff7ec] via-white to-[#fff7ec] relative overflow-hidden'}`}>
-        <div className="absolute inset-0 pointer-events-none">
-          <div className="absolute top-16 left-10 h-56 w-56 rounded-full bg-[#E09A18]/15 blur-3xl" />
-          <div className="absolute bottom-10 right-10 h-64 w-64 rounded-full bg-[#0A0A0A]/10 blur-3xl" />
-        </div>
-
+      <section className={`${isPaymentScreen ? 'fixed inset-0 z-[120] overflow-y-auto bg-white py-6' : 'py-10 relative overflow-hidden'}`}>
         <div className="container mx-auto px-6 relative">
-          {!isPaymentScreen && (
-          <div className="max-w-4xl mx-auto text-center mb-10">
-            <p className="text-sm uppercase tracking-[0.3em] text-[#E8600A] font-semibold mb-3">
-              Booking Flow
-            </p>
-            <h2 className="text-3xl md:text-4xl font-black text-gray-900 mb-4">
-              Complete Your Booking On This Page
-            </h2>
-            <p className="text-gray-600 max-w-2xl mx-auto">
-              The selected package stays visible here so customers can finish traveler details and payment without a popup interrupting the flow.
-            </p>
-          </div>
-          )}
-
-          <div className={`max-w-5xl mx-auto mb-6 rounded-2xl border border-[#ffba5a]/30 bg-white/80 backdrop-blur-lg px-5 py-4 shadow-lg ${isPaymentScreen ? 'hidden' : ''}`}>
-            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-[#E8600A] mb-1">Selected Cruise</p>
-            <div className="flex flex-col gap-1 md:flex-row md:items-center md:justify-between">
-              <h3 className="text-2xl font-bold text-gray-900">{selectedCruise}</h3>
-              <p className="text-sm font-semibold text-gray-700">Starting from ${selectedAmountUsd.toFixed(2)}</p>
-            </div>
-          </div>
-
-          {isPaymentScreen && (
-            <div className="max-w-5xl mx-auto mb-6 flex items-center justify-between rounded-2xl border border-[#dbeafe] bg-[#eff6ff] px-5 py-4">
-              <div>
-                <p className="text-sm font-bold text-[#1e3a8a]">Secure Payment Screen</p>
-                <p className="text-xs text-[#1e3a8a]">Header and booking marketing sections are hidden while you complete payment.</p>
-              </div>
-            </div>
-          )}
-
           <BookingModal
             key={`${selectedCruise}-${selectedAmountUsd}-${queryBookingReference}-${queryPaymentMode}`}
             isOpen={true}
-            onClose={() => {}}
+            onClose={handleBackToSelect}
             cruiseType={selectedCruise}
             amountUsd={selectedAmountUsd}
             initialPaymentMode={queryPaymentMode === 'card' ? 'card' : undefined}

--- a/public-website/src/app/booking/page.tsx
+++ b/public-website/src/app/booking/page.tsx
@@ -210,7 +210,7 @@ function BookingPageContent() {
                   </a>
                   <a
                     href="tel:+263712629336"
-                    className="flex items-center justify-center gap-3 p-4 rounded-xl bg-[#E8600A]/10 border border-[#ff9800]/20 hover:bg-[#ff9800] hover:text-black text-[#E8600A] transition-all duration-300 font-semibold"
+                    className="flex items-center justify-center gap-3 p-4 rounded-xl bg-[#E8600A]/10 border border-[#E8600A]/20 hover:bg-[#E8600A] hover:text-black text-[#E8600A] transition-all duration-300 font-semibold"
                   >
                     <FaPhone size={18} />
                     +263 712 629 336

--- a/public-website/src/app/booking/payment-status/page.tsx
+++ b/public-website/src/app/booking/payment-status/page.tsx
@@ -297,7 +297,7 @@ function PaymentStatusPageContent() {
             type="button"
             onClick={() => void verifyPayment()}
             disabled={status === 'checking'}
-            className="rounded-full bg-linear-to-r from-[#ffba5a] to-[#ff9800] hover:from-[#ff9800] hover:to-[#ff7700] text-black font-bold py-3 px-5 transition-all disabled:opacity-60"
+            className="rounded-full bg-linear-to-r from-[#E09A18] to-[#E8600A] hover:from-[#E8600A] hover:to-[#F47B1A] text-black font-bold py-3 px-5 transition-all disabled:opacity-60"
           >
             {status === 'checking' ? 'Checking...' : 'Check Again'}
           </button>

--- a/public-website/src/app/gallery/page.tsx
+++ b/public-website/src/app/gallery/page.tsx
@@ -55,7 +55,7 @@ export default function GalleryPage() {
         />
         <div className="absolute inset-0 bg-gradient-to-b from-black/60 via-black/40 to-black/70" />
         <div className="relative text-center text-white px-6">
-          <p className="text-sm uppercase tracking-[0.3em] text-[#ffba5a] font-semibold mb-3">
+          <p className="text-sm uppercase tracking-[0.3em] text-[#E09A18] font-semibold mb-3">
             Explore
           </p>
           <h1 className="text-4xl md:text-6xl font-black drop-shadow-lg">
@@ -65,10 +65,10 @@ export default function GalleryPage() {
       </section>
 
       {/* Gallery Grid */}
-      <section className="py-16 bg-gradient-to-b from-white via-[#fff7ec] to-white relative overflow-hidden">
+      <section className="py-16 bg-gradient-to-b from-white via-[#FFF9F5] to-white relative overflow-hidden">
         <div className="absolute inset-0 pointer-events-none">
-          <div className="absolute top-10 right-10 w-48 h-48 bg-[#ffba5a]/15 blur-3xl rounded-full" />
-          <div className="absolute bottom-10 left-10 w-56 h-56 bg-[#ff9800]/10 blur-3xl rounded-full" />
+          <div className="absolute top-10 right-10 w-48 h-48 bg-[#E09A18]/15 blur-3xl rounded-full" />
+          <div className="absolute bottom-10 left-10 w-56 h-56 bg-[#E8600A]/10 blur-3xl rounded-full" />
         </div>
 
         <div className="container mx-auto px-6 relative">
@@ -80,8 +80,8 @@ export default function GalleryPage() {
                 onClick={() => setActiveCategory(cat.key)}
                 className={`px-4 py-2 rounded-full text-sm font-semibold transition-all duration-300 ${
                   activeCategory === cat.key
-                    ? "bg-gradient-to-r from-[#ffba5a] to-[#ff9800] text-black shadow-lg"
-                    : "bg-white/60 backdrop-blur-md border border-white/50 text-gray-700 hover:border-[#ff9800]/50"
+                    ? "bg-gradient-to-r from-[#E09A18] to-[#E8600A] text-black shadow-lg"
+                    : "bg-white/60 backdrop-blur-md border border-white/50 text-gray-700 hover:border-[#E8600A]/50"
                 }`}
               >
                 {cat.icon && <cat.icon size={14} className="inline mr-1" />}{cat.label}

--- a/public-website/src/components/BookingModal.tsx
+++ b/public-website/src/components/BookingModal.tsx
@@ -1093,7 +1093,7 @@ export default function BookingModal({
         {/* Modal content */}
         <div className="p-6 md:p-8 lg:p-10">
           <div className="text-center mb-6">
-            <div className="inline-flex items-center justify-center w-14 h-14 rounded-full bg-linear-to-r from-[#ffba5a] to-[#ff9800] mb-4">
+            <div className="inline-flex items-center justify-center w-14 h-14 rounded-full bg-linear-to-r from-[#E09A18] to-[#E8600A] mb-4">
               <svg className="w-7 h-7 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
               </svg>
@@ -1152,7 +1152,7 @@ export default function BookingModal({
                     value={selectedDate}
                     onChange={(e) => setSelectedDate(e.target.value)}
                     min={new Date().toISOString().split('T')[0]}
-                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#ff9800] focus:border-transparent transition"
+                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#E8600A] focus:border-transparent transition"
                   />
                 </div>
 
@@ -1166,7 +1166,7 @@ export default function BookingModal({
                     value={numberOfPeople}
                     onChange={(e) => setNumberOfPeople(e.target.value)}
                     min="1"
-                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#ff9800] focus:border-transparent transition"
+                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#E8600A] focus:border-transparent transition"
                   />
                 </div>
 
@@ -1177,35 +1177,35 @@ export default function BookingModal({
                     placeholder="Full name"
                     value={traveler.fullName}
                     onChange={(e) => setTraveler((prev) => ({ ...prev, fullName: e.target.value }))}
-                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#ff9800] focus:border-transparent transition"
+                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#E8600A] focus:border-transparent transition"
                   />
                   <input
                     type="email"
                     placeholder="Email address"
                     value={traveler.email}
                     onChange={(e) => setTraveler((prev) => ({ ...prev, email: e.target.value }))}
-                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#ff9800] focus:border-transparent transition"
+                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#E8600A] focus:border-transparent transition"
                   />
                   <input
                     type="text"
                     placeholder="Phone / WhatsApp number"
                     value={traveler.phone}
                     onChange={(e) => setTraveler((prev) => ({ ...prev, phone: e.target.value }))}
-                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#ff9800] focus:border-transparent transition"
+                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#E8600A] focus:border-transparent transition"
                   />
                   <input
                     type="text"
                     placeholder="Country (optional)"
                     value={traveler.country}
                     onChange={(e) => setTraveler((prev) => ({ ...prev, country: e.target.value }))}
-                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#ff9800] focus:border-transparent transition"
+                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#E8600A] focus:border-transparent transition"
                   />
                   <textarea
                     placeholder="Special requests (dietary, accessibility, occasion, pickup details)"
                     value={traveler.specialRequests}
                     onChange={(e) => setTraveler((prev) => ({ ...prev, specialRequests: e.target.value }))}
                     rows={3}
-                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#ff9800] focus:border-transparent transition"
+                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#E8600A] focus:border-transparent transition"
                   />
                   <label className="flex items-start gap-2 text-sm text-gray-700">
                     <input
@@ -1229,7 +1229,7 @@ export default function BookingModal({
                           placeholder="Full name"
                           value={item.name}
                           onChange={(e) => setTravelers((prev) => prev.map((row, i) => (i === index ? { ...row, name: e.target.value } : row)))}
-                          className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#ff9800] focus:border-transparent transition"
+                          className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#E8600A] focus:border-transparent transition"
                         />
                         <input
                           type="number"
@@ -1237,33 +1237,33 @@ export default function BookingModal({
                           min="1"
                           value={item.age}
                           onChange={(e) => setTravelers((prev) => prev.map((row, i) => (i === index ? { ...row, age: e.target.value } : row)))}
-                          className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#ff9800] focus:border-transparent transition"
+                          className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#E8600A] focus:border-transparent transition"
                         />
                         <input
                           type="text"
                           placeholder="Nationality"
                           value={item.nationality}
                           onChange={(e) => setTravelers((prev) => prev.map((row, i) => (i === index ? { ...row, nationality: e.target.value } : row)))}
-                          className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#ff9800] focus:border-transparent transition"
+                          className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#E8600A] focus:border-transparent transition"
                         />
                         <input
                           type="text"
                           placeholder="Gender"
                           value={item.gender}
                           onChange={(e) => setTravelers((prev) => prev.map((row, i) => (i === index ? { ...row, gender: e.target.value } : row)))}
-                          className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#ff9800] focus:border-transparent transition"
+                          className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#E8600A] focus:border-transparent transition"
                         />
                         <input
                           type="text"
                           placeholder="ID / Passport number"
                           value={item.idNumber}
                           onChange={(e) => setTravelers((prev) => prev.map((row, i) => (i === index ? { ...row, idNumber: e.target.value } : row)))}
-                          className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#ff9800] focus:border-transparent transition sm:col-span-2"
+                          className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#E8600A] focus:border-transparent transition sm:col-span-2"
                         />
                         <select
                           value={item.travelerType}
                           onChange={(e) => setTravelers((prev) => prev.map((row, i) => (i === index ? { ...row, travelerType: e.target.value as 'adult' | 'child' } : row)))}
-                          className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#ff9800] focus:border-transparent transition"
+                          className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#E8600A] focus:border-transparent transition"
                         >
                           <option value="adult">Adult</option>
                           <option value="child">Child</option>
@@ -1273,7 +1273,7 @@ export default function BookingModal({
                           placeholder="Medical / Dietary requirements (optional)"
                           value={item.medicalDietaryRequirements}
                           onChange={(e) => setTravelers((prev) => prev.map((row, i) => (i === index ? { ...row, medicalDietaryRequirements: e.target.value } : row)))}
-                          className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#ff9800] focus:border-transparent transition"
+                          className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#E8600A] focus:border-transparent transition"
                         />
                         <div className="sm:col-span-2">
                           <label className="block text-sm font-semibold text-gray-700 mb-2">
@@ -1283,7 +1283,7 @@ export default function BookingModal({
                             type="file"
                             accept=".jpg,.jpeg,.png,.pdf"
                             onChange={(e) => handleTravelerDocumentChange(index, e.target.files?.[0] || null)}
-                            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#ff9800] focus:border-transparent transition"
+                            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#E8600A] focus:border-transparent transition"
                           />
                           {item.idDocumentName && (
                             <p className="mt-2 text-xs text-gray-500">Attached: {item.idDocumentName}</p>
@@ -1302,7 +1302,7 @@ export default function BookingModal({
               </>
             )}
 
-            <div className="bg-linear-to-r from-[#fff7ec] to-[#ffe8cc] border border-[#ffba5a]/30 rounded-lg p-4">
+            <div className="bg-linear-to-r from-[#FFF9F5] to-[#FFE0C8] border border-[#E09A18]/30 rounded-lg p-4">
               <p className="text-sm text-gray-700">
                 <strong className="text-gray-900">Estimated total:</strong> USD {totalAmount.toFixed(2)}
               </p>
@@ -1366,7 +1366,7 @@ export default function BookingModal({
                     onChange={(e) => setEcocash({ msisdn: sanitizeMsisdn(e.target.value) })}
                     inputMode="numeric"
                     placeholder="263771234567 or 0771234567"
-                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#ff9800] focus:border-transparent transition"
+                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#E8600A] focus:border-transparent transition"
                   />
                   <p className="mt-2 text-xs text-gray-500">
                     Accepted formats: {(paymentConfig?.ecocash.accepted_formats || ['2637XXXXXXXX', '07XXXXXXXX']).join(' or ')}
@@ -1381,7 +1381,7 @@ export default function BookingModal({
                           key={testMsisdn}
                           type="button"
                           onClick={() => setEcocash({ msisdn: testMsisdn })}
-                          className="rounded-full border border-[#ff9800] px-3 py-1 text-xs font-semibold text-[#ff9800] transition hover:bg-[#fff2e0]"
+                          className="rounded-full border border-[#E8600A] px-3 py-1 text-xs font-semibold text-[#E8600A] transition hover:bg-[#FFF3E8]"
                         >
                           {testMsisdn}
                         </button>
@@ -1393,7 +1393,7 @@ export default function BookingModal({
                   type="button"
                   onClick={checkEcoCashPaymentStatus}
                   disabled={isSubmitting || !lastMerchantReference || lastPaymentChannel !== 'ecocash'}
-                  className="w-full rounded-full border border-[#ff9800] text-[#ff9800] font-semibold py-2.5 hover:bg-[#fff2e0] transition disabled:opacity-50"
+                  className="w-full rounded-full border border-[#E8600A] text-[#E8600A] font-semibold py-2.5 hover:bg-[#FFF3E8] transition disabled:opacity-50"
                 >
                   Check EcoCash Status
                 </button>
@@ -1451,7 +1451,7 @@ export default function BookingModal({
                           key={testPan}
                           type="button"
                           onClick={() => setCard((prev) => ({ ...prev, cardNumber: testPan, expiry: '02/28', cvv: '123' }))}
-                          className="rounded-full border border-[#ff9800] px-3 py-1 text-xs font-semibold text-[#ff9800] transition hover:bg-[#fff2e0]"
+                          className="rounded-full border border-[#E8600A] px-3 py-1 text-xs font-semibold text-[#E8600A] transition hover:bg-[#FFF3E8]"
                         >
                           {`${testPan.slice(0, 4)} **** **** ${testPan.slice(-4)}`}
                         </button>
@@ -1474,7 +1474,7 @@ export default function BookingModal({
                           inputMode="numeric"
                           autoComplete="cc-number"
                           placeholder="5413330089020020"
-                          className="w-full px-4 py-3 pr-12 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#ff9800] focus:border-transparent transition"
+                          className="w-full px-4 py-3 pr-12 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#E8600A] focus:border-transparent transition"
                         />
                         {sanitizePan(card.cardNumber).length >= 4 && (
                           <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-2xl" aria-hidden="true">
@@ -1503,7 +1503,7 @@ export default function BookingModal({
                           inputMode="numeric"
                           autoComplete="cc-exp"
                           placeholder="02/28"
-                          className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#ff9800] focus:border-transparent transition"
+                          className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#E8600A] focus:border-transparent transition"
                         />
                       </div>
                       <div>
@@ -1518,7 +1518,7 @@ export default function BookingModal({
                           inputMode="numeric"
                           autoComplete="cc-csc"
                           placeholder="123"
-                          className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#ff9800] focus:border-transparent transition"
+                          className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#E8600A] focus:border-transparent transition"
                         />
                       </div>
                     </div>
@@ -1529,7 +1529,7 @@ export default function BookingModal({
                     type="button"
                     onClick={() => void complete3DSPayment()}
                     disabled={isSubmitting}
-                    className="w-full rounded-full border border-[#ff9800] text-[#ff9800] font-semibold py-2.5 hover:bg-[#fff2e0] transition disabled:opacity-50"
+                    className="w-full rounded-full border border-[#E8600A] text-[#E8600A] font-semibold py-2.5 hover:bg-[#FFF3E8] transition disabled:opacity-50"
                   >
                     Retry 3DS Status Check
                   </button>
@@ -1538,7 +1538,7 @@ export default function BookingModal({
             )}
 
             {paymentMessage && (
-              <div className="rounded-lg border border-[#ffba5a]/40 bg-[#fff9ef] p-3 text-sm text-gray-700">
+              <div className="rounded-lg border border-[#E09A18]/40 bg-[#FFF9F5] p-3 text-sm text-gray-700">
                 {paymentMessage}
               </div>
             )}
@@ -1566,7 +1566,7 @@ export default function BookingModal({
                 <button
                   type="button"
                   onClick={() => setCheckoutStep('details')}
-                  className="flex-1 px-6 py-3 border border-[#ff9800] text-[#ff9800] font-semibold rounded-full hover:bg-[#fff2e0] transition"
+                  className="flex-1 px-6 py-3 border border-[#E8600A] text-[#E8600A] font-semibold rounded-full hover:bg-[#FFF3E8] transition"
                 >
                   Back to Details
                 </button>
@@ -1574,7 +1574,7 @@ export default function BookingModal({
               <button
                 type="submit"
                 disabled={isSubmitting}
-                className="flex-1 px-6 py-3 bg-linear-to-r from-[#ffba5a] to-[#ff9800] hover:from-[#ff9800] hover:to-[#ff7700] text-black font-bold rounded-full shadow-lg hover:shadow-xl transition-all duration-300"
+                className="flex-1 px-6 py-3 bg-linear-to-r from-[#E09A18] to-[#E8600A] hover:from-[#E8600A] hover:to-[#F47B1A] text-black font-bold rounded-full shadow-lg hover:shadow-xl transition-all duration-300"
               >
                 {isSubmitting
                   ? 'Processing...'

--- a/public-website/src/components/BookingModal.tsx
+++ b/public-website/src/components/BookingModal.tsx
@@ -1099,22 +1099,37 @@ export default function BookingModal({
               </svg>
             </div>
             <h2 className="text-2xl md:text-3xl font-bold text-gray-900 mb-2">
-              Book Your Cruise
+              {checkoutStep === 'details' ? 'Your Details' : 'Secure Payment'}
             </h2>
             <p className="text-gray-600">
               {cruiseType}
             </p>
           </div>
 
-          <div className="mb-6 flex items-center justify-center gap-2 text-xs font-semibold uppercase tracking-[0.12em]">
-            <span className={`rounded-full px-3 py-1 ${checkoutStep === 'details' ? 'bg-[#ff9800] text-black' : 'bg-gray-100 text-gray-600'}`}>
-              1. Booking Details
-            </span>
-            <span className="text-gray-400"><FaArrowRight size={12} /></span>
-            <span className={`rounded-full px-3 py-1 ${checkoutStep === 'payment' ? 'bg-[#ff9800] text-black' : 'bg-gray-100 text-gray-600'}`}>
-              2. Secure Payment
-            </span>
-          </div>
+          {isPagePresentation && (
+            <div className="mb-6 flex items-center justify-center gap-2 text-xs font-semibold uppercase tracking-[0.12em]">
+              <span className="rounded-full bg-gray-100 text-gray-500 px-3 py-1 line-through">1. Choose Cruise</span>
+              <span className="text-gray-400"><FaArrowRight size={12} /></span>
+              <span className={`rounded-full px-3 py-1 ${checkoutStep === 'details' ? 'bg-[#C8102E] text-white' : 'bg-gray-100 text-gray-500 line-through'}`}>
+                2. Your Details
+              </span>
+              <span className="text-gray-400"><FaArrowRight size={12} /></span>
+              <span className={`rounded-full px-3 py-1 ${checkoutStep === 'payment' ? 'bg-[#C8102E] text-white' : 'bg-gray-100 text-gray-400'}`}>
+                3. Payment
+              </span>
+            </div>
+          )}
+          {!isPagePresentation && (
+            <div className="mb-6 flex items-center justify-center gap-2 text-xs font-semibold uppercase tracking-[0.12em]">
+              <span className={`rounded-full px-3 py-1 ${checkoutStep === 'details' ? 'bg-[#C8102E] text-white' : 'bg-gray-100 text-gray-600'}`}>
+                1. Your Details
+              </span>
+              <span className="text-gray-400"><FaArrowRight size={12} /></span>
+              <span className={`rounded-full px-3 py-1 ${checkoutStep === 'payment' ? 'bg-[#C8102E] text-white' : 'bg-gray-100 text-gray-600'}`}>
+                2. Payment
+              </span>
+            </div>
+          )}
 
           {isTestMode && (
             <div className="mb-5 rounded-2xl border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-900">
@@ -1545,7 +1560,7 @@ export default function BookingModal({
                 onClick={onClose}
                 className="flex-1 px-6 py-3 border border-gray-300 text-gray-700 font-semibold rounded-full hover:bg-gray-50 transition"
               >
-                Cancel
+                {isPagePresentation && checkoutStep === 'details' ? '← Back to Cruises' : 'Cancel'}
               </button>
               {checkoutStep === 'payment' && !hasExistingBooking && (
                 <button


### PR DESCRIPTION
## Summary

- Removes `requireCvv: false` from `wpwlOptions` in both `card-checkout/page.tsx` and `page-fixed.tsx`
- This was incorrectly making CVV optional for all card types (Visa, Mastercard, Amex) on the OPPWA hosted widget
- OPPWA's default behaviour already handles Maestro's optional CVV natively — no override needed

## Test plan

- [ ] Load the COPYandPAY hosted checkout — CVV field should be present and required
- [ ] Attempt to submit without CVV — widget should block submission

https://claude.ai/code/session_01P2wCYVUWtni8XjH7T12xJ8

---
_Generated by [Claude Code](https://claude.ai/code/session_01P2wCYVUWtni8XjH7T12xJ8)_