### PR TITLE
Remove ECI from initial card debit to unblock 3DS challenge

### DIFF
--- a/whatsappcrm_backend/cbz_integration/services.py
+++ b/whatsappcrm_backend/cbz_integration/services.py
@@ -467,7 +467,10 @@ class IVeriClient:
             'MerchantReference': merchant_reference,
             # MD echoed through iVeri → ACS → TermUrl callback so we can recover merchant_reference
             'MD': merchant_reference,
-            'ECI': ECI_ECOMMERCE,
+            # Do NOT send ECI on the initial debit — iVeri uses the card's
+            # enrolment status to decide whether to issue a 3DS challenge.
+            # Sending ECI '7' here tells iVeri "no 3DS" and suppresses the challenge.
+            # ECI is submitted on the completion call (5 = authenticated, 6 = attempted).
         }
 
         # TermUrl tells iVeri (and subsequently the ACS) where to redirect the


### PR DESCRIPTION
## Problem

3DS challenge was never being issued. The initial card `Debit` request included `ECI: '7'` (Card Not Present, no 3DS). iVeri interprets this as the merchant explicitly opting out of 3DS and skips the ACS challenge entirely.

## Fix

Remove ECI from the initial `debit_card()` payload. With no ECI, iVeri checks the card's enrolment status and issues a challenge when the card is enrolled. ECI is still correctly submitted on the **completion** call after the cardholder authenticates (`5` = fully authenticated, `6` = attempted).

## Test plan

- [ ] Use a 3DS-enrolled test card from the iVeri test card list
- [ ] Initiate a card debit via `/crm-api/payments/cbz/card/debit/`
- [ ] Confirm response contains `requires_3ds: true` with `challenge.ACSURL` and `challenge.PaReq`
- [ ] Complete the ACS challenge and confirm `pares_received: true` in UAT export

https://claude.ai/code/session_01K4ByUS2b6EKpVAWhj3L4kM

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4ByUS2b6EKpVAWhj3L4kM)_