### PR TITLE
Rewrite 3DS integration for iVeri 3DS 2 (was incorrectly 3DS v1)

### DIFF
--- a/public-website/src/components/BookingModal.tsx
+++ b/public-website/src/components/BookingModal.tsx
@@ -973,13 +973,12 @@ export default function BookingModal({
 
     try {
       setIsSubmitting(true);
-      setPaymentMessage('Submitting card payment...');
+      setPaymentMessage('Initiating 3D Secure authentication...');
 
-      const response = await fetch(`${API_BASE}/crm-api/payments/cbz/card/debit/`, {
+      // Step 1: request 3DS 2 enrollment form data from the backend
+      const enrollResponse = await fetch(`${API_BASE}/crm-api/payments/cbz/card/3ds/enroll/`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           pan,
           expiry_date: expiryDate,
@@ -991,40 +990,45 @@ export default function BookingModal({
         }),
       });
 
-      const result = await response.json();
-      const resolvedBookingReference = result.booking_reference || initialBookingReference || '';
+      const enrollResult = await enrollResponse.json();
+
+      if (!enrollResult.success) {
+        setPaymentMessage(enrollResult.message || 'Could not initiate 3DS authentication. Please try again.');
+        return;
+      }
+
+      const resolvedBookingReference = enrollResult.booking_reference || initialBookingReference || '';
       if (resolvedBookingReference) {
         setActiveBookingReference(resolvedBookingReference);
         setSessionItem(PENDING_BOOKING_REFERENCE_KEY, resolvedBookingReference);
       }
-      if (result.success && result.requires_3ds) {
-        setCanReturnToWhatsApp(launchedFromWhatsApp);
-        setPaymentMessage('3DS verification required. Redirecting to your bank authentication page...');
-        submit3DSChallenge(result.challenge || {}, result.merchant_reference);
-        return;
+      setSessionItem(PENDING_3DS_REF_KEY, enrollResult.merchant_reference);
+      setSessionItem(PENDING_PAYMENT_CHANNEL_KEY, 'card');
+      if (launchedFromWhatsApp) {
+        setSessionItem(RETURN_TO_WHATSAPP_KEY, '1');
       }
+      setLastMerchantReference(enrollResult.merchant_reference);
+      setCanReturnToWhatsApp(launchedFromWhatsApp);
 
-      if (result.success && !result.pending) {
-        setLastPaymentChannel('card');
-        removeSessionItem(PENDING_PAYMENT_CHANNEL_KEY);
-        setCanReturnToWhatsApp(launchedFromWhatsApp);
-        setPaymentMessage(buildApprovalMessage(result.merchant_reference, result.gateway_mode));
-        return;
-      }
-
-      if (result.pending) {
-        setLastMerchantReference(result.merchant_reference || '');
-        setLastPaymentChannel('card');
-        setCanReturnToWhatsApp(launchedFromWhatsApp);
-        if (result.merchant_reference) {
-          setSessionItem(PENDING_3DS_REF_KEY, result.merchant_reference);
-          setSessionItem(PENDING_PAYMENT_CHANNEL_KEY, 'card');
-        }
-        setPaymentMessage('Payment is pending. If this was a 3DS flow, click Complete 3DS Payment after authentication.');
-        return;
-      }
-
-      setPaymentMessage(result.message || 'Payment failed.');
+      // Step 2: auto-submit the enrollment form to iVeri — browser takes over from here.
+      // iVeri drives the 3DS challenge and POSTs the result back to CBZ_3DS_RETURN_URL,
+      // which completes the Debit and redirects the browser to /booking/payment-status.
+      setPaymentMessage('Redirecting to 3D Secure authentication...');
+      const form = document.createElement('form');
+      form.method = 'POST';
+      form.action = enrollResult.enrollment_url;
+      form.style.display = 'none';
+      Object.entries(enrollResult.fields as Record<string, string>).forEach(([key, value]) => {
+        if (!value) return;
+        const input = document.createElement('input');
+        input.type = 'hidden';
+        input.name = key;
+        input.value = value;
+        form.appendChild(input);
+      });
+      document.body.appendChild(form);
+      form.submit();
+      return;
     } catch {
       setPaymentMessage('Payment request failed. Please try again.');
     } finally {

--- a/whatsappcrm_backend/.env.example
+++ b/whatsappcrm_backend/.env.example
@@ -124,11 +124,15 @@ CBZ_CERTIFICATE_ID=df09b961-8d62-4fde-a83c-855f933f5bcd   # Certificate ID (GUID
 CBZ_MERCHANT_PROFILE_ID=617614                             # Your merchant profile ID from iVeri
 CBZ_MODE=Test                                               # 'Test' for sandbox, 'LIVE' for production
 CBZ_PORTAL_URL=https://portal.host.iveri.com               # iVeri Gateway Portal URL (usually the same for test/live)
-# 3DS v1 TermUrl: where the ACS (bank authentication server) redirects the browser after the
-# cardholder completes the challenge.  Must be the full public URL of the Next.js
-# /api/3ds/callback route, e.g. https://kalisafaris.com/api/3ds/callback
-# Required for card payments through the CBZ direct REST path (not needed for COPYandPAY).
+# 3DS v1 TermUrl (legacy, no longer used — iVeri uses 3DS 2)
 CBZ_3DS_TERM_URL=https://yourdomain.com/api/3ds/callback
+
+# 3DS 2: full public URL of the Django ReturnUrl endpoint.
+# iVeri POSTs the 3DS authentication result here after the cardholder completes enrollment.
+CBZ_3DS_RETURN_URL=https://backend.yourdomain.com/crm-api/payments/cbz/card/3ds/return/
+
+# 3DS 2: base URL of the Next.js frontend (used to redirect browser after 3DS completes).
+CBZ_3DS_FRONTEND_BASE=https://yourdomain.com
 
 # --- COPYandPAY (ZimSwitch / OPPWA) ---
 # Keep these in environment variables only. Do not hardcode in source files.

--- a/whatsappcrm_backend/cbz_integration/constants.py
+++ b/whatsappcrm_backend/cbz_integration/constants.py
@@ -10,6 +10,9 @@ IVERI_PORTAL_URL_TEST = 'https://portal.host.iveri.com'  # Same host, Mode field
 # REST API endpoints (relative to portal URL)
 IVERI_REST_TRANSACTIONS = '/api/transactions'
 
+# 3DS 2 enrollment endpoint (relative to portal URL) — form POST, browser-initiated
+IVERI_3DS_ENROLLMENT = '/threedsecure/EnrollmentInitial'
+
 # SOAP certificate lifecycle defaults
 IVERI_SOAP_TIMEOUT = 60
 
@@ -33,10 +36,17 @@ COMMAND_LOOKUP = 'Lookup'
 MODE_TEST = 'Test'
 MODE_LIVE = 'LIVE'
 
-# ECI (Electronic Commerce Indicator) values
-ECI_ECOMMERCE = '7'           # Card Not Present, no 3DS authentication
-ECI_3DS_AUTHENTICATED = '5'   # Fully 3DS authenticated — liability shifts to issuer
-ECI_3DS_ATTEMPTED = '6'       # 3DS attempted but not completed (e.g. card not enrolled)
+# ECI (Electronic Commerce Indicator) values for EcoCash (legacy numeric)
+ECI_ECOMMERCE = '7'           # Card Not Present, no 3DS (used for EcoCash only)
+
+# ECI string values for 3DS 2 (iVeri Enterprise uses string labels, not numeric)
+ECI_3DS2_AUTHENTICATED = 'ThreeDSecure'         # Fully authenticated — ECI 05/02
+ECI_3DS2_ATTEMPTED = 'ThreeDSecureAttempted'    # Attempted — ECI 06/01
+ECI_3DS2_SECURE_CHANNEL = 'SecureChannel'       # Secure channel — ECI 07
+
+# Legacy 3DS v1 ECI numeric values (kept for reference/compatibility)
+ECI_3DS_AUTHENTICATED = '5'   # 3DS v1 fully authenticated
+ECI_3DS_ATTEMPTED = '6'       # 3DS v1 attempted
 
 # Result codes
 RESULT_CODE_SUCCESS = '0'

--- a/whatsappcrm_backend/cbz_integration/services.py
+++ b/whatsappcrm_backend/cbz_integration/services.py
@@ -22,6 +22,7 @@ from .constants import (
     ECOCASH_PAN_PREFIX,
     IVERI_API_VERSION,
     IVERI_REST_TRANSACTIONS,
+    IVERI_3DS_ENROLLMENT,
     IVERI_SOAP_TIMEOUT,
     COMMAND_DEBIT,
     COMMAND_AUTHORISATION,
@@ -441,6 +442,62 @@ class IVeriClient:
 
     # ─── Card Payments (Website Only) ────────────────────────────────
 
+    def get_3ds_enrollment_form_data(
+        self,
+        pan: str,
+        expiry_date: str,
+        amount: Decimal,
+        currency: str,
+        merchant_reference: str,
+        return_url: str,
+        cvv: str = '',
+    ) -> Dict[str, Any]:
+        """
+        Build the form-data fields for the iVeri 3DS 2 EnrollmentInitial POST.
+
+        The caller (frontend) must submit these as a form POST to enrollment_url
+        so that iVeri can drive the browser through the 3DS challenge (if required)
+        and POST the authentication result back to return_url.
+
+        Args:
+            pan: Card PAN
+            expiry_date: Expiry in MMYY format
+            amount: Transaction amount (major units)
+            currency: Currency code
+            merchant_reference: Unique merchant reference
+            return_url: Backend URL where iVeri POSTs the 3DS result
+            cvv: Card security code (optional per iVeri spec)
+
+        Returns:
+            {
+                'enrollment_url': str,    # Target for the form action
+                'fields': dict,           # Hidden input name→value pairs
+            }
+        """
+        amount_cents = str(int(amount * 100))
+        enrollment_url = f"{self.config.portal_url.rstrip('/')}{IVERI_3DS_ENROLLMENT}"
+
+        fields: Dict[str, str] = {
+            'ApplicationID': self.config.application_id,
+            'MerchantReference': merchant_reference,
+            'Amount': amount_cents,
+            'Currency': currency,
+            'PAN': pan,
+            'ExpiryDate': expiry_date,
+            'ReturnUrl': return_url,
+        }
+        if cvv:
+            fields['CardSecurityCode'] = cvv
+
+        logger.info(
+            "3DS enrollment form prepared | ref=%s amount=%s %s return_url=%s",
+            merchant_reference, amount, currency, return_url,
+        )
+        return {
+            'enrollment_url': enrollment_url,
+            'fields': fields,
+        }
+
     def debit_card(
         self,
         pan: str,
@@ -452,18 +509,24 @@ class IVeriClient:
         threed_secure_data: Optional[Dict[str, str]] = None,
     ) -> Dict[str, Any]:
         """
-        Process card payment (Visa/Mastercard) via iVeri.
+        Process card payment (Visa/Mastercard) via iVeri REST API.
 
-        For website-initiated payments with optional 3D Secure data.
+        For 3DS 2: call get_3ds_enrollment_form_data() first, complete the 3DS
+        flow via the browser, then call this method with the auth data returned
+        by iVeri to the ReturnUrl.
 
         Args:
-            pan: Card number (16 digits)
+            pan: Card number
             expiry_date: Expiry in MMYY format (e.g., '0228')
             cvv: Card CVV/CVC
             amount: Amount to charge
             currency: Currency code ('USD' or 'ZWG')
             merchant_reference: Unique merchant reference
-            threed_secure_data: Optional 3DS authentication data
+            threed_secure_data: 3DS 2 authentication fields from ReturnUrl result:
+                CardHolderAuthenticationData, CardHolderAuthenticationID,
+                ElectronicCommerceIndicator, ThreeDSecure_DSTransID,
+                ThreeDSecure_ProtocolVersion, ThreeDSecure_AuthenticationType,
+                ThreeDSecure_VEResEnrolled, ThreeDSecure_RequestID
 
         Returns:
             iVeri API response dict
@@ -477,20 +540,9 @@ class IVeriClient:
             'ExpiryDate': expiry_date,
             'CardSecurityCode': cvv,
             'MerchantReference': merchant_reference,
-            # MD echoed through iVeri → ACS → TermUrl callback so we can recover merchant_reference
-            'MD': merchant_reference,
-            # Do NOT send ECI on the initial debit — iVeri uses the card's
-            # enrolment status to decide whether to issue a 3DS challenge.
-            # Sending ECI '7' here tells iVeri "no 3DS" and suppresses the challenge.
-            # ECI is submitted on the completion call (5 = authenticated, 6 = attempted).
         }
 
-        # TermUrl tells iVeri (and subsequently the ACS) where to redirect the
-        # browser after 3DS authentication.  Required for 3DS v1 to work end-to-end.
-        if self.config.term_url:
-            transaction_data['TermUrl'] = self.config.term_url
-
-        # Add 3D Secure data if provided (caller may override TermUrl or add PaReq)
+        # Include 3DS 2 authentication data if provided
         if threed_secure_data:
             transaction_data.update(threed_secure_data)
 

--- a/whatsappcrm_backend/cbz_integration/urls.py
+++ b/whatsappcrm_backend/cbz_integration/urls.py
@@ -6,6 +6,8 @@ from .views import (
     cbz_copyandpay_prepare_view,
     cbz_copyandpay_status_view,
     cbz_card_3ds_complete_view,
+    cbz_card_3ds_enroll_view,
+    cbz_card_3ds_return_view,
     cbz_query_view,
     cbz_callback_view,
     cbz_certificate_generate_view,
@@ -26,6 +28,12 @@ urlpatterns = [
     path('card/debit/', cbz_card_debit_view, name='card_debit'),
     path('copyandpay/prepare/', cbz_copyandpay_prepare_view, name='copyandpay_prepare'),
     path('copyandpay/status/', cbz_copyandpay_status_view, name='copyandpay_status'),
+
+    # 3DS 2 flow: enroll → browser submits to iVeri → iVeri POSTs to return
+    path('card/3ds/enroll/', cbz_card_3ds_enroll_view, name='card_3ds_enroll'),
+    path('card/3ds/return/', cbz_card_3ds_return_view, name='card_3ds_return'),
+
+    # Legacy 3DS v1 completion (kept for any in-flight transactions)
     path('card/3ds/complete/', cbz_card_3ds_complete_view, name='card_3ds_complete'),
 
     # Transaction status query

--- a/whatsappcrm_backend/cbz_integration/views.py
+++ b/whatsappcrm_backend/cbz_integration/views.py
@@ -22,7 +22,8 @@ from decimal import Decimal, InvalidOperation
 from typing import Any, Dict, Optional
 import requests
 from django.conf import settings
-from django.http import JsonResponse, HttpRequest
+from django.core import signing
+from django.http import JsonResponse, HttpRequest, HttpResponseRedirect
 from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods
@@ -1592,6 +1593,310 @@ def cbz_certificate_renew_view(request: HttpRequest) -> JsonResponse:
     except Exception as exc:
         logger.exception("CBZ certificate renewal failed")
         return JsonResponse({"success": False, "message": str(exc)}, status=502)
+
+
+# ─── 3DS 2 Enrollment + ReturnUrl ───────────────────────────────────
+
+_3DS_PAN_SALT = 'cbz_3ds_pan_v1'
+_3DS_PAN_MAX_AGE = 900  # 15 minutes — enough for a 3DS challenge
+
+
+@csrf_exempt
+@require_http_methods(["POST"])
+def cbz_card_3ds_enroll_view(request: HttpRequest) -> JsonResponse:
+    """
+    POST /crm-api/payments/cbz/card/3ds/enroll/
+
+    Prepares a 3DS 2 enrollment request for the iVeri Gateway.
+
+    The frontend must auto-submit the returned form fields to enrollment_url
+    so that iVeri can drive the browser through the 3DS challenge and POST
+    the authentication result back to the ReturnUrl (cbz_card_3ds_return_view).
+
+    Request JSON:
+    {
+        "pan": "4070427646039018",
+        "expiry_date": "0228",
+        "cvv": "123",
+        "amount": 25.00,
+        "currency": "USD",
+        "booking_reference": "KS-ABC123"   // optional
+    }
+
+    Response:
+    {
+        "success": true,
+        "merchant_reference": "KS-XXXXXXXXXXXX",
+        "enrollment_url": "https://portal.host.iveri.com/threedsecure/EnrollmentInitial",
+        "fields": {
+            "ApplicationID": "...",
+            "MerchantReference": "...",
+            "Amount": "2500",
+            "Currency": "USD",
+            "PAN": "4070427646039018",
+            "ExpiryDate": "0228",
+            "CardSecurityCode": "123",
+            "ReturnUrl": "https://backend.kalisafaris.com/crm-api/payments/cbz/card/3ds/return/"
+        }
+    }
+    """
+    try:
+        payload = json.loads(request.body.decode('utf-8'))
+    except Exception:
+        return JsonResponse({"success": False, "message": "Invalid JSON"}, status=400)
+
+    required = ["pan", "expiry_date", "cvv", "amount", "currency"]
+    missing = [k for k in required if k not in payload]
+    if missing:
+        return JsonResponse(
+            {"success": False, "message": f"Missing fields: {', '.join(missing)}"},
+            status=400,
+        )
+
+    try:
+        amount = Decimal(str(payload['amount']))
+        if amount <= 0:
+            raise ValueError("Amount must be positive")
+    except (InvalidOperation, ValueError) as e:
+        return JsonResponse({"success": False, "message": f"Invalid amount: {e}"}, status=400)
+
+    pan = re.sub(r'\D', '', str(payload.get('pan', '')))
+    expiry_date = re.sub(r'\D', '', str(payload.get('expiry_date', '')))
+    cvv = re.sub(r'\D', '', str(payload.get('cvv', '')))
+
+    if len(pan) < 13 or len(pan) > 19:
+        return JsonResponse({"success": False, "message": "Invalid card number length"}, status=400)
+    active_config = _get_active_config()
+    is_test_mode = (active_config.mode == 'Test') if active_config else True
+    if not is_test_mode and not _is_luhn_valid(pan):
+        return JsonResponse({"success": False, "message": "Card number failed validation"}, status=400)
+    if not _is_valid_expiry_mm_yy(expiry_date):
+        return JsonResponse({"success": False, "message": "Invalid or expired card expiry date"}, status=400)
+    if len(cvv) < 3 or len(cvv) > 4:
+        return JsonResponse({"success": False, "message": "Invalid CVV"}, status=400)
+
+    currency = str(payload.get('currency', 'USD')).upper()
+    merchant_ref = f"KS-{uuid.uuid4().hex[:12].upper()}"
+    masked_pan = f"{pan[:4]}****{pan[-4:]}" if len(pan) >= 8 else "****"
+
+    # ReturnUrl — backend endpoint that receives the 3DS result from iVeri
+    return_url = getattr(settings, 'CBZ_3DS_RETURN_URL', '') or ''
+    if not return_url:
+        logger.warning(
+            "CBZ_3DS_RETURN_URL not configured — iVeri cannot POST 3DS result back. "
+            "Set CBZ_3DS_RETURN_URL to the public URL of /crm-api/payments/cbz/card/3ds/return/"
+        )
+        return JsonResponse(
+            {"success": False, "message": "3DS return URL not configured. Contact support."},
+            status=503,
+        )
+
+    try:
+        booking = _resolve_or_create_booking(payload, amount)
+    except Exception as e:
+        logger.warning("Error resolving/creating booking for 3DS enrollment: %s", e)
+        booking = None
+
+    txn = CBZTransaction.objects.create(
+        merchant_reference=merchant_ref,
+        payment_type=CBZTransaction.PaymentType.CARD,
+        masked_pan=masked_pan,
+        amount=amount,
+        currency=currency,
+        command='Debit',
+        status=CBZTransaction.TransactionStatus.INITIATED,
+        booking=booking,
+    )
+
+    # Temporarily sign the card data so the ReturnUrl handler can complete the Debit
+    # without the frontend needing to re-submit the PAN.
+    signed_card = signing.dumps(
+        {'pan': pan, 'expiry': expiry_date, 'cvv': cvv},
+        salt=_3DS_PAN_SALT,
+    )
+    txn.gateway_response = {'_signed_card': signed_card, '_3ds_enrollment_initiated': True}
+    txn.save(update_fields=['gateway_response'])
+
+    client = _build_client()
+    enrollment = client.get_3ds_enrollment_form_data(
+        pan=pan,
+        expiry_date=expiry_date,
+        amount=amount,
+        currency=currency,
+        merchant_reference=merchant_ref,
+        return_url=return_url,
+        cvv=cvv,
+    )
+
+    return JsonResponse({
+        "success": True,
+        "merchant_reference": merchant_ref,
+        "booking_reference": booking.booking_reference if booking else None,
+        "enrollment_url": enrollment['enrollment_url'],
+        "fields": enrollment['fields'],
+    })
+
+
+@csrf_exempt
+@require_http_methods(["POST"])
+def cbz_card_3ds_return_view(request: HttpRequest) -> HttpResponseRedirect:
+    """
+    POST /crm-api/payments/cbz/card/3ds/return/
+
+    iVeri POSTs the 3DS 2 authentication result to this URL after the
+    cardholder completes the enrollment/challenge flow.
+
+    On ResultCode "0": retrieves signed card data, submits the Debit with
+    3DS authentication fields, then redirects the browser to the frontend
+    payment-status page.
+
+    On non-zero ResultCode: marks the transaction failed and redirects to
+    the frontend with an error.
+    """
+    # Parse the form POST from iVeri
+    payload: Dict[str, Any] = {}
+    content_type = request.content_type or ''
+    if 'application/json' in content_type:
+        try:
+            payload = json.loads(request.body.decode('utf-8'))
+        except Exception:
+            payload = {}
+    else:
+        payload = {
+            k: (v[0] if isinstance(v, list) and len(v) == 1 else v)
+            for k, v in request.POST.items()
+        }
+
+    logger.info("3DS ReturnUrl received | keys=%s", list(payload.keys()))
+
+    merchant_ref = str(payload.get('MerchantReference') or '').strip()
+    result_code = str(payload.get('ResultCode') or '').strip()
+
+    frontend_base = getattr(settings, 'CBZ_3DS_FRONTEND_BASE', '') or ''
+
+    def _redirect(path: str) -> HttpResponseRedirect:
+        return HttpResponseRedirect(f"{frontend_base.rstrip('/')}{path}")
+
+    if not merchant_ref:
+        logger.warning("3DS ReturnUrl: no MerchantReference in payload")
+        return _redirect('/booking/payment-status?channel=card&error=no_reference')
+
+    txn = CBZTransaction.objects.filter(merchant_reference=merchant_ref).first()
+    if not txn:
+        logger.warning("3DS ReturnUrl: transaction %s not found", merchant_ref)
+        return _redirect(f'/booking/payment-status?channel=card&error=not_found&ref={merchant_ref}')
+
+    # Store the 3DS auth data on the transaction
+    stored = txn.gateway_response or {}
+    stored['_3ds_return_payload'] = _scrub_pci_fields(payload)
+    stored['_3ds_pares_received'] = True  # reuse existing UAT export field
+
+    if result_code != '0':
+        txn.result_code = result_code
+        txn.result_description = str(payload.get('ResultDescription') or 'Authentication failed')
+        txn.status = CBZTransaction.TransactionStatus.DECLINED
+        txn.gateway_response = stored
+        txn.save()
+        logger.info("3DS ReturnUrl: authentication failed | ref=%s code=%s", merchant_ref, result_code)
+        return _redirect(
+            f'/booking/payment-status?channel=card&ref={merchant_ref}'
+            f'&error=3ds_failed&result_code={result_code}'
+        )
+
+    # 3DS authentication succeeded — collect auth fields for the Debit
+    three_ds_auth = {}
+    for field in (
+        'CardHolderAuthenticationData',
+        'CardHolderAuthenticationID',
+        'ElectronicCommerceIndicator',
+        'ThreeDSecure_DSTransID',
+        'ThreeDSecure_ProtocolVersion',
+        'ThreeDSecure_AuthenticationType',
+        'ThreeDSecure_VEResEnrolled',
+        'ThreeDSecure_RequestID',
+        'JWT',
+    ):
+        value = payload.get(field)
+        if value:
+            three_ds_auth[field] = str(value)
+
+    stored['_3ds_auth_data'] = three_ds_auth
+    txn.gateway_response = stored
+    txn.save(update_fields=['gateway_response'])
+
+    # Retrieve the temporarily signed card data and complete the Debit
+    signed_card = stored.get('_signed_card', '')
+    if not signed_card:
+        logger.error("3DS ReturnUrl: no signed card data for %s — cannot complete Debit", merchant_ref)
+        txn.status = CBZTransaction.TransactionStatus.FAILED
+        txn.result_description = '3DS completed but card data unavailable for charge'
+        txn.save(update_fields=['status', 'result_description', 'gateway_response'])
+        return _redirect(f'/booking/payment-status?channel=card&ref={merchant_ref}&error=card_data_missing')
+
+    try:
+        card_data = signing.loads(signed_card, salt=_3DS_PAN_SALT, max_age=_3DS_PAN_MAX_AGE)
+    except signing.SignatureExpired:
+        logger.error("3DS ReturnUrl: signed card data expired for %s", merchant_ref)
+        txn.status = CBZTransaction.TransactionStatus.FAILED
+        txn.result_description = '3DS session expired — please restart payment'
+        txn.save(update_fields=['status', 'result_description'])
+        return _redirect(f'/booking/payment-status?channel=card&ref={merchant_ref}&error=session_expired')
+    except Exception:
+        logger.exception("3DS ReturnUrl: could not load signed card data for %s", merchant_ref)
+        txn.status = CBZTransaction.TransactionStatus.FAILED
+        txn.result_description = '3DS completion error'
+        txn.save(update_fields=['status', 'result_description'])
+        return _redirect(f'/booking/payment-status?channel=card&ref={merchant_ref}&error=internal')
+
+    # Clear the signed card data before making the Debit call
+    stored.pop('_signed_card', None)
+    txn.gateway_response = stored
+    txn.save(update_fields=['gateway_response'])
+
+    client = _build_client()
+    try:
+        response = client.debit_card(
+            pan=card_data['pan'],
+            expiry_date=card_data['expiry'],
+            cvv=card_data.get('cvv', ''),
+            amount=txn.amount,
+            currency=txn.currency,
+            merchant_reference=merchant_ref,
+            threed_secure_data=three_ds_auth or None,
+        )
+
+        result = IVeriClient.get_result(response)
+        is_approved = IVeriClient.is_approved(response)
+        is_pending = IVeriClient.is_pending(response)
+
+        _apply_gateway_result_to_transaction(
+            txn, result,
+            approved=is_approved,
+            pending=is_pending,
+            raw_response=response,
+        )
+
+        if is_approved:
+            txn.booking = _finalize_booking_reference_if_temporary(txn.booking)
+            if txn.booking:
+                existing = Payment.objects.filter(
+                    booking=txn.booking,
+                    transaction_reference=txn.merchant_reference,
+                ).exists()
+                if not existing:
+                    _record_payment(txn, txn.booking)
+
+        logger.info(
+            "3DS ReturnUrl: Debit complete | ref=%s approved=%s pending=%s",
+            merchant_ref, is_approved, is_pending,
+        )
+
+    except Exception:
+        logger.exception("3DS ReturnUrl: Debit failed | ref=%s", merchant_ref)
+        txn.status = CBZTransaction.TransactionStatus.FAILED
+        txn.save(update_fields=['status'])
+
+    return _redirect(f'/booking/payment-status?channel=card&ref={merchant_ref}&provider=cbz')
 
 
 # ─── Helper Functions ────────────────────────────────────────────────

--- a/whatsappcrm_backend/whatsappcrm_backend/settings.py
+++ b/whatsappcrm_backend/whatsappcrm_backend/settings.py
@@ -582,9 +582,16 @@ CBZ_CERTIFICATE_ID = os.getenv('CBZ_CERTIFICATE_ID', '')  # GUID used in REST tr
 CBZ_APPLICATION_ID = os.getenv('CBZ_APPLICATION_ID', '')  # GUID from acquiring bank (CBZ)
 CBZ_MERCHANT_PROFILE_ID = os.getenv('CBZ_MERCHANT_PROFILE_ID', '')  # Merchant profile ID for iVeri
 CBZ_MODE = os.getenv('CBZ_MODE', 'Test')  # 'Test' or 'LIVE'
-# Full public URL of the Next.js /api/3ds/callback route — sent to iVeri as TermUrl
-# so the ACS knows where to redirect the browser after cardholder authentication.
+# Legacy 3DS v1 TermUrl (no longer used — iVeri uses 3DS 2)
 CBZ_3DS_TERM_URL = os.getenv('CBZ_3DS_TERM_URL', '')
+
+# 3DS 2: public URL of the Django /crm-api/payments/cbz/card/3ds/return/ endpoint.
+# iVeri POSTs the authentication result here after the cardholder completes enrollment.
+CBZ_3DS_RETURN_URL = os.getenv('CBZ_3DS_RETURN_URL', '')
+
+# 3DS 2: base URL of the frontend (Next.js) app — used to redirect the browser
+# after 3DS completes (e.g. https://kalisafaris.com).
+CBZ_3DS_FRONTEND_BASE = os.getenv('CBZ_3DS_FRONTEND_BASE', '')
 
 # Optional SOAP certificate lifecycle configuration.
 CBZ_CERTIFICATE_SOAP_URL = os.getenv('CBZ_CERTIFICATE_SOAP_URL', '')


### PR DESCRIPTION
## Problem

Our 3DS implementation was built for 3DS v1 (PaReq/PaRes/ACSURL/TermUrl). iVeri Enterprise uses **3DS 2**, which is a completely different protocol with a separate enrollment endpoint. That's why every card transaction approved straight through without any challenge — the gateway ignored our TermUrl entirely.

## What iVeri 3DS 2 actually requires (per Enterprise Developer Guide)

1. POST form data to `/threedsecure/EnrollmentInitial` (separate endpoint, browser-initiated)
2. iVeri proxies to 3DS MPI, drives the browser through the challenge if required
3. iVeri POSTs authentication result to merchant `ReturnUrl`
4. Merchant submits Debit to `/api/transactions` with 3DS 2 auth fields (`CardHolderAuthenticationData`, `CardHolderAuthenticationID`, `ElectronicCommerceIndicator` as string, `ThreeDSecure_DSTransID`, `ThreeDSecure_ProtocolVersion`)

## Changes

| File | What changed |
|------|-------------|
| `constants.py` | Add `IVERI_3DS_ENROLLMENT` endpoint; add `ECI_3DS2_AUTHENTICATED='ThreeDSecure'`, `ECI_3DS2_ATTEMPTED='ThreeDSecureAttempted'` |
| `services.py` | Add `get_3ds_enrollment_form_data()` method; clean up `debit_card()` |
| `views.py` | New `cbz_card_3ds_enroll_view` (returns enrollment form fields to frontend); new `cbz_card_3ds_return_view` (iVeri ReturnUrl — verifies auth, submits Debit with 3DS data, redirects browser) |
| `urls.py` | Add `/card/3ds/enroll/` and `/card/3ds/return/` |
| `settings.py` | Add `CBZ_3DS_RETURN_URL` and `CBZ_3DS_FRONTEND_BASE` |
| `BookingModal.tsx` | Switch card flow from direct Debit to enrollment → form POST → backend handles Debit |

## Environment variables to set

```
CBZ_3DS_RETURN_URL=https://backend.kalisafaris.com/crm-api/payments/cbz/card/3ds/return/
CBZ_3DS_FRONTEND_BASE=https://kalisafaris.com
```

## Test plan

- [ ] Set env vars above and restart server
- [ ] Use Scenario 3 test card `4070427646039018` (Challenged Full auth)
- [ ] Initiate card checkout — browser should redirect to iVeri 3DS page
- [ ] Complete challenge — iVeri should POST to `/card/3ds/return/`
- [ ] Logs should show `3DS ReturnUrl received` then `Debit complete`
- [ ] Browser redirects to `/booking/payment-status?channel=card&ref=KS-...`
- [ ] Use Scenario 1 card `4070426536557386` — frictionless, should complete without challenge
- [ ] Run `export_uat_report --include-3ds` and confirm `pares_received: true`

https://claude.ai/code/session_01K4ByUS2b6EKpVAWhj3L4kM

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4ByUS2b6EKpVAWhj3L4kM)_