### PR TITLE
Restrict COPYandPAY default brand to PRIVATE_LABEL; fix error mismapping

### DIFF
--- a/public-website/src/app/booking/card-checkout/page-fixed.tsx
+++ b/public-website/src/app/booking/card-checkout/page-fixed.tsx
@@ -165,12 +165,14 @@ function setWpwlOptions(onWidgetError: (msg: string, expired: boolean) => void) 
       const msg  = error?.message || '';
       const isExpired =
         name === 'InvalidCheckoutIdError' ||
-        code === '200.300.404' ||
         msg.includes('No payment session found');
+      const isInvalidParam = code === '200.300.404';
       onWidgetError(
         isExpired
           ? 'Your payment session has expired. Sessions last 30 minutes — please go back and start a new payment.'
-          : `Payment error: ${msg || code || name || 'Unknown error'}. Please try again.`,
+          : isInvalidParam
+            ? 'This card type or payment detail is not supported for this merchant account. Please try a different card.'
+            : `Payment error: ${msg || code || name || 'Unknown error'}. Please try again.`,
         isExpired,
       );
     },
@@ -187,7 +189,7 @@ function CardCheckoutContent() {
 
   const checkoutId = (searchParams.get('checkoutId') || '').trim();
   const merchantReference = (searchParams.get('merchantRef') || '').trim();
-  const brands = (searchParams.get('brands') || 'VISA MASTER AMEX PRIVATE_LABEL').trim();
+  const brands = (searchParams.get('brands') || 'PRIVATE_LABEL').trim();
   const widgetScriptUrl = (searchParams.get('widget') || '').trim();
   const integrity = (searchParams.get('integrity') || '').trim();
   let returnUrl = (searchParams.get('returnUrl') || '/booking/payment-status?channel=card').trim();

--- a/public-website/src/app/booking/card-checkout/page.tsx
+++ b/public-website/src/app/booking/card-checkout/page.tsx
@@ -165,12 +165,14 @@ function setWpwlOptions(onWidgetError: (msg: string, expired: boolean) => void) 
       const msg  = error?.message || '';
       const isExpired =
         name === 'InvalidCheckoutIdError' ||
-        code === '200.300.404' ||
         msg.includes('No payment session found');
+      const isInvalidParam = code === '200.300.404';
       onWidgetError(
         isExpired
           ? 'Your payment session has expired. Sessions last 30 minutes — please go back and start a new payment.'
-          : `Payment error: ${msg || code || name || 'Unknown error'}. Please try again.`,
+          : isInvalidParam
+            ? 'This card type or payment detail is not supported for this merchant account. Please try a different card.'
+            : `Payment error: ${msg || code || name || 'Unknown error'}. Please try again.`,
         isExpired,
       );
     },
@@ -187,7 +189,7 @@ function CardCheckoutContent() {
 
   const checkoutId = (searchParams.get('checkoutId') || '').trim();
   const merchantReference = (searchParams.get('merchantRef') || '').trim();
-  const brands = (searchParams.get('brands') || 'VISA MASTER AMEX PRIVATE_LABEL').trim();
+  const brands = (searchParams.get('brands') || 'PRIVATE_LABEL').trim();
   const widgetScriptUrl = (searchParams.get('widget') || '').trim();
   const integrity = (searchParams.get('integrity') || '').trim();
   const returnUrl = (searchParams.get('returnUrl') || '/booking/payment-status?channel=card').trim();

--- a/public-website/src/components/BookingModal.tsx
+++ b/public-website/src/components/BookingModal.tsx
@@ -922,7 +922,7 @@ export default function BookingModal({
         const checkoutUrl = new URL(`${window.location.origin}/booking/card-checkout`);
         checkoutUrl.searchParams.set('checkoutId', String(result.checkout_id));
         checkoutUrl.searchParams.set('merchantRef', merchantRef);
-        checkoutUrl.searchParams.set('brands', String(result.brands || 'VISA MASTER AMEX PRIVATE_LABEL'));
+        checkoutUrl.searchParams.set('brands', String(result.brands || 'PRIVATE_LABEL'));
         checkoutUrl.searchParams.set('widget', String(result.widget_script_url || ''));
         checkoutUrl.searchParams.set('returnUrl', resultUrl.toString());
         if (result.integrity) {

--- a/whatsappcrm_backend/.env.example
+++ b/whatsappcrm_backend/.env.example
@@ -141,6 +141,6 @@ COPYANDPAY_BASE_URL=https://eu-test.oppwa.com
 COPYANDPAY_ENTITY_ID=your-copyandpay-entity-id
 COPYANDPAY_BEARER_TOKEN=your-copyandpay-auth-bearer-token
 COPYANDPAY_TEST_MODE=EXTERNAL
-COPYANDPAY_BRANDS=VISA MASTER AMEX PRIVATE_LABEL
+COPYANDPAY_BRANDS=PRIVATE_LABEL
 # Optional Subresource Integrity hash for paymentWidgets.js
 COPYANDPAY_WIDGET_INTEGRITY=

--- a/whatsappcrm_backend/cbz_integration/migrations/0006_alter_cbzconfig_copyandpay_brands_help_v2.py
+++ b/whatsappcrm_backend/cbz_integration/migrations/0006_alter_cbzconfig_copyandpay_brands_help_v2.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cbz_integration', '0005_alter_cbzconfig_copyandpay_brands_help'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='cbzconfig',
+            name='copyandpay_brands',
+            field=models.CharField(
+                blank=True,
+                null=True,
+                max_length=255,
+                help_text='Space-separated brands exposed by paymentWidgets. This merchant entityId is provisioned by ZimSwitch as Private Label only (default: PRIVATE_LABEL). Only brands enabled on your CBZ merchant account will appear in the widget.',
+            ),
+        ),
+    ]

--- a/whatsappcrm_backend/cbz_integration/models.py
+++ b/whatsappcrm_backend/cbz_integration/models.py
@@ -76,7 +76,7 @@ class CBZConfig(models.Model):
         max_length=255,
         blank=True,
         null=True,
-        help_text="Space-separated brands exposed by paymentWidgets (e.g. VISA MASTER AMEX PRIVATE_LABEL). PRIVATE_LABEL covers ZimSwitch private-label cards. Only brands enabled on your CBZ merchant account will appear in the widget."
+        help_text="Space-separated brands exposed by paymentWidgets. This merchant entityId is provisioned by ZimSwitch as Private Label only (default: PRIVATE_LABEL). Only brands enabled on your CBZ merchant account will appear in the widget."
     )
     copyandpay_widget_integrity = models.CharField(
         max_length=512,

--- a/whatsappcrm_backend/cbz_integration/views.py
+++ b/whatsappcrm_backend/cbz_integration/views.py
@@ -129,7 +129,7 @@ def _get_public_payment_config() -> Dict[str, Any]:
             'copyandpay': {
                 'enabled': bool(copyandpay_entity_id),
                 'base_url': copyandpay_base_url,
-                'brands': copyandpay_brands or 'VISA MASTER AMEX PRIVATE_LABEL',
+                'brands': copyandpay_brands or 'PRIVATE_LABEL',
             },
         },
     }
@@ -172,7 +172,7 @@ def _get_copyandpay_config() -> Dict[str, str]:
             (getattr(config, 'copyandpay_brands', '') if config else '')
             or getattr(settings, 'COPYANDPAY_BRANDS', '')
             or os.getenv('COPYANDPAY_BRANDS', '')
-            or 'VISA MASTER AMEX PRIVATE_LABEL'
+            or 'PRIVATE_LABEL'
         ).strip(),
         'integrity': (
             (getattr(config, 'copyandpay_widget_integrity', '') if config else '')


### PR DESCRIPTION
## Summary
- The CBZ/ZimSwitch `entityId` used for COPYandPAY is provisioned by ZimSwitch as **Private Label only** (confirmed via merchant credentials emails). Defaulting `data-brands` to `VISA MASTER AMEX PRIVATE_LABEL` was inviting `200.300.404` ("invalid or missing parameter") and "invalid brand" errors for card types this entity can't actually process. Changed the default to `PRIVATE_LABEL` only across backend (`views.py`, `models.py` help text, `.env.example`) and frontend (`BookingModal.tsx`, `page.tsx`, `page-fixed.tsx`).
- Fixed the card-checkout `onError` handler: OPPWA code `200.300.404` was being mismapped as "session expired." It now surfaces as an "unsupported card type for this merchant" message instead, since that's what it actually means per OPPWA's documented result codes.
- Added migration `0006` to update the `copyandpay_brands` help text (migration `0005` was already merged, so this stacks on top rather than editing history).

## Test plan
- [ ] Verify COPYandPAY checkout still completes successfully for a private-label test card.
- [ ] Verify a non-private-label/incompatible card now shows the new "card type not supported" message instead of "session expired."
- [ ] Run `python manage.py migrate` against the dev DB to confirm migration 0006 applies cleanly.

https://claude.ai/code/session_01K4ByUS2b6EKpVAWhj3L4kM


---
_Generated by [Claude Code](https://claude.ai/code/session_01K4ByUS2b6EKpVAWhj3L4kM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added 3D Secure 2 (3DS 2) authentication support for card payments
  * Implemented selectable brand-card interface in checkout UI

* **Improvements**
  * Enhanced error messaging for expired sessions and unsupported payment methods
  * Updated default payment method option to Private Label brand
  * Improved accepted payment badge display

<!-- end of auto-generated comment: release notes by coderabbit.ai -->