### PR TITLE
Stop sending shopperResultUrl in COPYandPAY checkout-creation request

### DIFF
--- a/whatsappcrm_backend/cbz_integration/views.py
+++ b/whatsappcrm_backend/cbz_integration/views.py
@@ -940,10 +940,12 @@ def cbz_copyandpay_prepare_view(request: HttpRequest) -> JsonResponse:
     if config['test_mode']:
         request_data['testMode'] = config['test_mode']
 
-    # OPPWA locks shopperResultUrl at checkout-creation time and rejects any
-    # later mismatch (even an added query param) when the widget submits the
-    # payment. So we embed merchant_ref here and hand the final URL back to
-    # the caller, who must use it verbatim as the payment form's action.
+    # NOTE: shopperResultUrl must NOT be sent in the /v1/checkouts prepare
+    # request. Per OPPWA's integration guide it belongs only on the payment
+    # form's action attribute (step 2). Sending it here as well causes OPPWA
+    # to reject the later widget submission with "shopperResultUrl was
+    # already set and cannot be overwritten" (200.300.404), even when the
+    # value is byte-for-byte identical.
     final_shopper_result_url = ''
     raw_shopper_result_url = str(payload.get('shopper_result_url') or '').strip()
     if raw_shopper_result_url:
@@ -951,7 +953,6 @@ def cbz_copyandpay_prepare_view(request: HttpRequest) -> JsonResponse:
         query = parse_qs(parsed.query)
         query['ref'] = [merchant_ref]
         final_shopper_result_url = urlunparse(parsed._replace(query=urlencode(query, doseq=True)))
-        request_data['shopperResultUrl'] = final_shopper_result_url
 
     headers = {
         'Authorization': f"Bearer {config['bearer_token']}",


### PR DESCRIPTION
## Summary
PR #91's fix wasn't enough — fresh production logs after that deploy still show the failure, with the exact same `shopperResultUrl` value in both the prepare request and the rejected status response:

```
prepare: shopperResultUrl=...&ref=KS-EC0A309FA87E
status:  parameterErrors: [{name: shopperResultUrl, value: ...&ref=KS-EC0A309FA87E, message: was already set and cannot be overwritten}]
```

Since the values are byte-for-byte identical, this isn't a mismatch issue — it's that **OPPWA doesn't allow `shopperResultUrl` to be sent at all during checkout creation** if the widget will also set it later via the form's `action` attribute. Re-checking OPPWA's own integration guide: the step-1 `curl` example for `/v1/checkouts` never includes `shopperResultUrl` — it only ever appears in step 2's `<form action="{shopperResultUrl}">`.

## Fix
`cbz_copyandpay_prepare_view` no longer adds `shopperResultUrl` to the `/v1/checkouts` request body. It still computes the final URL (with `ref=<merchant_ref>` embedded) and returns it to the frontend for use as the payment form's `action` — that part of #91 was correct and stays.

## Test plan
- [ ] Run a COPYandPAY sandbox payment end-to-end and confirm the status check returns a real approve/decline instead of `200.300.404`.

https://claude.ai/code/session_01K4ByUS2b6EKpVAWhj3L4kM


---
_Generated by [Claude Code](https://claude.ai/code/session_01K4ByUS2b6EKpVAWhj3L4kM)_