### PR TITLE
Remove unrelated hanna.co.zw/worldbet2.com domains from .env

### DIFF
--- a/whatsappcrm_backend/.env
+++ b/whatsappcrm_backend/.env
@@ -1,8 +1,8 @@
 # --- Mailu IMAP Fetcher Settings ---
 # These are used by the fetch_mailu_attachments management command.
-MAILU_IMAP_HOST=mail.hanna.co.zw
-MAILU_IMAP_USER=installations@hanna.co.zw
-MAILU_IMAP_PASS=PfungwaHanna2024
+MAILU_IMAP_HOST=mail.kalaisafaris.com
+MAILU_IMAP_USER=bookings@kalaisafaris.com
+MAILU_IMAP_PASS=REPLACE_WITH_REAL_MAILU_PASSWORD
 
 # --- Google Gemini API Settings ---
 GEMINI_API_KEY='your-google-ai-studio-api-key-here'
@@ -19,16 +19,16 @@ DJANGO_DEBUG=False # This MUST be False in production for security.
 # --- Domain and Host Settings ---
 # A comma-separated list of hosts your Django app will serve.
 # This should include your backend domain, server IP, and frontend domain (for WebSocket connections).
-DJANGO_ALLOWED_HOSTS='backend.hanna.co.zw,dashboard.hanna.co.zw,72.60.91.41,127.0.0.1,localhost,127.0.0.1,backend.kalaisafaris.com,dashboard.kalaisafaris.com,testbackend.worldbet2.com,www.testbackend.worldbet2.com'
+DJANGO_ALLOWED_HOSTS='localhost,127.0.0.1,72.60.91.41,backend.kalaisafaris.com,dashboard.kalaisafaris.com,kalaisafaris.com'
 
 # A comma-separated list of trusted origins for CSRF protection (for POST, PUT, etc.).
 # This MUST be your frontend's full domain with the https scheme.
-CSRF_TRUSTED_ORIGINS='http://localhost:5173,http://127.0.0.1:5173,https://dashboard.hanna.co.zw,http://dashboard.hanna.co.zw,https://backend.hanna.co.zw,http://backend.hanna.co.zw'
+CSRF_TRUSTED_ORIGINS='http://localhost:5173,http://127.0.0.1:5173,https://dashboard.kalaisafaris.com,http://dashboard.kalaisafaris.com,https://backend.kalaisafaris.com,http://backend.kalaisafaris.com,https://kalaisafaris.com,http://kalaisafaris.com'
 
 
 # A comma-separated list of origins allowed to make cross-site API requests.
 # This also MUST be your frontend's full domain.
-CORS_ALLOWED_ORIGINS='https://dashboard.hanna.co.zw,http://dashboard.hanna.co.zw'
+CORS_ALLOWED_ORIGINS='https://dashboard.kalaisafaris.com,http://dashboard.kalaisafaris.com,https://kalaisafaris.com,http://kalaisafaris.com'
 CORS_ALLOW_CREDENTIALS=True
 
 # --- Celery Settings ---
@@ -47,8 +47,8 @@ CONVERSATION_EXPIRY_DAYS='60'
 WHATSAPP_APP_SECRET='c189bbdaac02442a28216debfed60a8b'
 
 # --- Content Security Policy (CSP) Settings ---
-BACKEND_DOMAIN_FOR_CSP='backend.hanna.co.zw'
-FRONTEND_DOMAIN_FOR_CSP='dashboard.hanna.co.zw'
+BACKEND_DOMAIN_FOR_CSP='backend.kalaisafaris.com'
+FRONTEND_DOMAIN_FOR_CSP='dashboard.kalaisafaris.com'
 
 # --- Logging Settings (Optional - defaults are in settings.py) ---
 # DJANGO_LOG_LEVEL='INFO'


### PR DESCRIPTION
## Summary
- `DJANGO_ALLOWED_HOSTS`, `CSRF_TRUSTED_ORIGINS`, `CORS_ALLOWED_ORIGINS`, `BACKEND_DOMAIN_FOR_CSP`, and `FRONTEND_DOMAIN_FOR_CSP` all referenced an unrelated project's domain (`hanna.co.zw`) plus a stray `testbackend.worldbet2.com` entry. Replaced with the actual Kalai Safaris domains.
- Repointed the Mailu IMAP fetcher config (`MAILU_IMAP_HOST`/`MAILU_IMAP_USER`) at `kalaisafaris.com` and removed the real plaintext password that had been committed in cleartext, replacing it with a placeholder that needs to be set to the real value out-of-band.

## Note
⚠️ The Mailu password value `PfungwaHanna2024` was previously committed in plaintext on this branch's history. Recommend rotating that credential if it was a real, currently-active password.

## Test plan
- [x] `grep -i "hanna\|worldbet" whatsappcrm_backend/.env` returns no matches.


---
_Generated by [Claude Code](https://claude.ai/code/session_01K4ByUS2b6EKpVAWhj3L4kM)_