### PR TITLE
Fix iVeri -255 ECI error for cards that aren't 3DS-enrolled

### DIFF
--- a/whatsappcrm_backend/cbz_integration/services.py
+++ b/whatsappcrm_backend/cbz_integration/services.py
@@ -33,7 +33,6 @@ from .constants import (
     ECI_3DS_ATTEMPTED,
     ECI_3DS2_AUTHENTICATED,
     ECI_3DS2_ATTEMPTED,
-    ECI_3DS2_SECURE_CHANNEL,
     ECI_NUMERIC_TO_3DS2,
     RESULT_CODE_SUCCESS,
     STATUS_PENDING,
@@ -585,14 +584,14 @@ class IVeriClient:
         # fall back to the enrolment status instead of passing it through.
         if threed_secure_data:
             three_ds = dict(threed_secure_data)
-            known_enums = {ECI_3DS2_AUTHENTICATED, ECI_3DS2_ATTEMPTED, ECI_3DS2_SECURE_CHANNEL}
+            known_enums = {ECI_3DS2_AUTHENTICATED, ECI_3DS2_ATTEMPTED}
             eci = str(three_ds.get('ElectronicCommerceIndicator') or '').strip()
             enrolled = str(three_ds.get('ThreeDSecure_VEResEnrolled') or '').strip().upper()
             if eci in ECI_NUMERIC_TO_3DS2:
                 eci = ECI_NUMERIC_TO_3DS2[eci]
             elif eci in known_enums:
                 pass  # already iVeri's string enum
-            elif not eci or enrolled == 'Y':
+            elif enrolled == 'Y':
                 eci = ECI_3DS2_AUTHENTICATED
             else:
                 eci = ECI_3DS2_ATTEMPTED

--- a/whatsappcrm_backend/cbz_integration/services.py
+++ b/whatsappcrm_backend/cbz_integration/services.py
@@ -32,6 +32,8 @@ from .constants import (
     ECI_3DS_AUTHENTICATED,
     ECI_3DS_ATTEMPTED,
     ECI_3DS2_AUTHENTICATED,
+    ECI_3DS2_ATTEMPTED,
+    ECI_3DS2_SECURE_CHANNEL,
     ECI_NUMERIC_TO_3DS2,
     RESULT_CODE_SUCCESS,
     STATUS_PENDING,
@@ -575,12 +577,26 @@ class IVeriClient:
         # (06/01) — NOT the numeric ECI the ReturnUrl relays. Sending the numeric
         # value gives "ElectronicCommerceIndicator ThreeDSecure or
         # ThreeDSecureAttempted required". Ref: iVeri "3D Secure" guide.
+        #
+        # Cards that aren't enrolled in 3DS (ThreeDSecure_VEResEnrolled != 'Y')
+        # skip the cardholder challenge entirely, so the ReturnUrl relays an ECI
+        # outside the known 05/02/06/01 set (or none at all). Forwarding that
+        # raw/unrecognised value causes the same "...required" rejection, so
+        # fall back to the enrolment status instead of passing it through.
         if threed_secure_data:
             three_ds = dict(threed_secure_data)
+            known_enums = {ECI_3DS2_AUTHENTICATED, ECI_3DS2_ATTEMPTED, ECI_3DS2_SECURE_CHANNEL}
             eci = str(three_ds.get('ElectronicCommerceIndicator') or '').strip()
-            three_ds['ElectronicCommerceIndicator'] = (
-                ECI_NUMERIC_TO_3DS2.get(eci, eci) if eci else ECI_3DS2_AUTHENTICATED
-            )
+            enrolled = str(three_ds.get('ThreeDSecure_VEResEnrolled') or '').strip().upper()
+            if eci in ECI_NUMERIC_TO_3DS2:
+                eci = ECI_NUMERIC_TO_3DS2[eci]
+            elif eci in known_enums:
+                pass  # already iVeri's string enum
+            elif not eci or enrolled == 'Y':
+                eci = ECI_3DS2_AUTHENTICATED
+            else:
+                eci = ECI_3DS2_ATTEMPTED
+            three_ds['ElectronicCommerceIndicator'] = eci
             transaction_data.update(three_ds)
 
         payload = self._build_payload(COMMAND_DEBIT, transaction_data)

--- a/whatsappcrm_backend/cbz_integration/tests.py
+++ b/whatsappcrm_backend/cbz_integration/tests.py
@@ -181,6 +181,29 @@ class IVeriClientPayloadTest(TestCase):
             self.assertEqual(txn['ThreeDSecure_DSTransID'], 'DS-1')
             self.assertEqual(txn['ThreeDSecure_ProtocolVersion'], '2.1.0')
 
+    @patch('cbz_integration.services.IVeriClient._load_config_from_db', return_value=None)
+    def test_debit_card_3ds_not_enrolled_falls_back_to_attempted(self, mock_db):
+        """When the card isn't 3DS-enrolled, iVeri's ReturnUrl relays an ECI
+        outside the known 05/02/06/01 set (or omits it). Forwarding that raw
+        value causes "ElectronicCommerceIndicator ThreeDSecure or
+        ThreeDSecureAttempted required", so it should fall back to the
+        "attempted" enum instead."""
+        client = IVeriClient(config=self.config)
+        with patch.object(client, '_execute') as mock_execute:
+            mock_execute.return_value = {'Transaction': {'ResultCode': '0', 'Status': 'Approved'}}
+            client.debit_card(
+                pan='5189000000009697', expiry_date='1230', cvv='123',
+                amount=Decimal('25.00'), currency='USD',
+                merchant_reference='KS-3DS-NOT-ENROLLED',
+                threed_secure_data={
+                    'ElectronicCommerceIndicator': '07',  # unrecognised/not-3DS ECI
+                    'ThreeDSecure_VEResEnrolled': 'N',
+                    'ThreeDSecure_RequestID': 'REQ-1',
+                },
+            )
+            txn = mock_execute.call_args[0][0]['Transaction']
+            self.assertEqual(txn['ElectronicCommerceIndicator'], 'ThreeDSecureAttempted')
+
     def test_missing_certificate_id_raises_value_error(self):
         with self.assertRaises(ValueError):
             IVeriClient(config=IVeriConfig(

--- a/whatsappcrm_backend/cbz_integration/tests.py
+++ b/whatsappcrm_backend/cbz_integration/tests.py
@@ -204,6 +204,26 @@ class IVeriClientPayloadTest(TestCase):
             txn = mock_execute.call_args[0][0]['Transaction']
             self.assertEqual(txn['ElectronicCommerceIndicator'], 'ThreeDSecureAttempted')
 
+    @patch('cbz_integration.services.IVeriClient._load_config_from_db', return_value=None)
+    def test_debit_card_3ds_not_enrolled_no_eci_still_attempted(self, mock_db):
+        """A not-enrolled card with no ElectronicCommerceIndicator at all must
+        still fall back to "attempted", not "authenticated" — there's no
+        evidence of authentication just because the field is missing."""
+        client = IVeriClient(config=self.config)
+        with patch.object(client, '_execute') as mock_execute:
+            mock_execute.return_value = {'Transaction': {'ResultCode': '0', 'Status': 'Approved'}}
+            client.debit_card(
+                pan='5189000000009697', expiry_date='1230', cvv='123',
+                amount=Decimal('25.00'), currency='USD',
+                merchant_reference='KS-3DS-NOT-ENROLLED-NO-ECI',
+                threed_secure_data={
+                    'ThreeDSecure_VEResEnrolled': 'N',
+                    'ThreeDSecure_RequestID': 'REQ-2',
+                },
+            )
+            txn = mock_execute.call_args[0][0]['Transaction']
+            self.assertEqual(txn['ElectronicCommerceIndicator'], 'ThreeDSecureAttempted')
+
     def test_missing_certificate_id_raises_value_error(self):
         with self.assertRaises(ValueError):
             IVeriClient(config=IVeriConfig(


### PR DESCRIPTION
## Summary
- Fixes the iVeri `-255 "ElectronicCommerceIndicator ThreeDSecure or ThreeDSecureAttempted required"` error seen in production logs for card payments where the card isn't enrolled in 3DS.
- `IVeriClient.debit_card()` previously only translated numeric ECI `05`/`02`/`06`/`01` to iVeri's expected string enum (`ThreeDSecure` / `ThreeDSecureAttempted`). When `ThreeDSecure_VEResEnrolled != 'Y'`, iVeri's `/3ds/return/` callback relays an ECI value outside that set, and the unrecognised raw value was forwarded to the Debit call as-is, causing iVeri to reject the transaction.
- Now falls back to `ThreeDSecureAttempted` for any unrecognised ECI when the card wasn't enrolled (or `ThreeDSecure` when it was), instead of passing through a value iVeri doesn't accept.

## Test plan
- [x] Added `test_debit_card_3ds_not_enrolled_falls_back_to_attempted` in `cbz_integration/tests.py` reproducing the not-enrolled case.
- [x] Ran `python manage.py test cbz_integration` (sqlite) — all card/3DS/payload tests pass; pre-existing failures are unrelated Redis/Celery signal tests that fail identically on `main` in this sandbox (no Redis available).

## Note on the other errors in the pasted logs
The `"Incorrect Mode specified for ApplicationID ..."` and `"Unauthorised ApplicationStatus for ApplicationID ..."` errors are **not** code bugs — they're iVeri/CBZ account-provisioning issues:
- `{79A854AC-...-76D1F127DB97}` is only provisioned for `Test` mode on iVeri's side (rejected when `Mode=LIVE` is sent).
- `{FFEA2D49-...-2D82E42FD04D}` hasn't been authorised for live transactions yet.

The app already reads the active `CBZConfig` from the DB on every request (no caching), so mode switches in `/admin/cbz_integration/cbzconfig/` take effect immediately — confirmed in the logs. Getting LIVE payments working requires CBZ/iVeri to activate a LIVE-mode `ApplicationID` on their end; no code change can fix that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Br2w1M162izdtiXtSfCqfX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved card payment handling for 3D Secure responses so unsupported or missing indicator values are now translated into valid payment indicators.
  * Fixed fallback behavior for cards that are not enrolled in 3D Secure, helping transactions proceed with the correct status instead of sending unrecognized values.
  * Added coverage for not-enrolled card scenarios to ensure the correct payment indicator is used consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->