### PR TITLE
Decline card payments when iVeri gives no CardHolderAuthenticationData

### DIFF
--- a/whatsappcrm_backend/cbz_integration/tests.py
+++ b/whatsappcrm_backend/cbz_integration/tests.py
@@ -858,6 +858,7 @@ class CBZCard3DSViewTests(TestCase):
         self.assertEqual(response.status_code, 302)
         self.assertIn('error=3ds_not_enrolled', response.url)
         self.assertEqual(txn.status, CBZTransaction.TransactionStatus.DECLINED)
+        self.assertEqual(txn.result_code, '255')
         mock_client.debit_card.assert_not_called()
 
 

--- a/whatsappcrm_backend/cbz_integration/tests.py
+++ b/whatsappcrm_backend/cbz_integration/tests.py
@@ -21,6 +21,7 @@ from .views import (
     cbz_ecocash_debit_view,
     cbz_card_debit_view,
     cbz_card_3ds_complete_view,
+    cbz_card_3ds_return_view,
     cbz_certificate_generate_view,
     cbz_certificate_renew_view,
 )
@@ -819,6 +820,45 @@ class CBZCard3DSViewTests(TestCase):
         self.assertTrue(payload.get('pending'))
         self.assertEqual(txn.status, CBZTransaction.TransactionStatus.PENDING)
         self.assertEqual(txn.gateway_response.get('_signed_card'), 'SIGNED-DATA')
+
+    @patch('cbz_integration.views._build_client')
+    def test_3ds_return_declines_when_no_cardholder_auth_data(self, mock_build_client):
+        """When the card isn't 3DS-enrolled, iVeri's ACS never returns
+        CardHolderAuthenticationData. Submitting the Debit anyway gets
+        rejected with -255 "Missing CardHolderAuthenticationData", so the
+        ReturnUrl handler must decline locally without attempting it."""
+        mock_client = MagicMock()
+        mock_build_client.return_value = mock_client
+
+        txn = CBZTransaction.objects.create(
+            merchant_reference='KS-3DS-NOT-ENROLLED-RET',
+            payment_type=CBZTransaction.PaymentType.CARD,
+            masked_pan='4070****9018',
+            amount=Decimal('25.00'),
+            currency='USD',
+            command='Debit',
+            status=CBZTransaction.TransactionStatus.PENDING,
+            gateway_response={'_signed_card': 'SIGNED-DATA'},
+        )
+
+        request = self.factory.post(
+            '/crm-api/payments/cbz/card/3ds/return/',
+            data={
+                'MerchantReference': txn.merchant_reference,
+                'ResultCode': '0',
+                'ElectronicCommerceIndicator': '07',
+                'ThreeDSecure_VEResEnrolled': 'N',
+                'ThreeDSecure_RequestID': 'REQ-1',
+            },
+        )
+
+        response = cbz_card_3ds_return_view(request)
+        txn.refresh_from_db()
+
+        self.assertEqual(response.status_code, 302)
+        self.assertIn('error=3ds_not_enrolled', response.url)
+        self.assertEqual(txn.status, CBZTransaction.TransactionStatus.DECLINED)
+        mock_client.debit_card.assert_not_called()
 
 
 class IVeriCertificateClientTests(TestCase):

--- a/whatsappcrm_backend/cbz_integration/views.py
+++ b/whatsappcrm_backend/cbz_integration/views.py
@@ -1870,6 +1870,28 @@ def cbz_card_3ds_return_view(request: HttpRequest) -> HttpResponseRedirect:
 
     stored['_3ds_auth_data'] = three_ds_auth
     txn.gateway_response = stored
+
+    # iVeri's Debit hard-requires CardHolderAuthenticationData whenever a 3DS
+    # ECI is sent. Cards that aren't 3DS-enrolled never get this field from
+    # the ACS/enrollment step, and iVeri rejects the Debit with -255 "Missing
+    # CardHolderAuthenticationData" — there's no valid substitute value, so
+    # decline here rather than attempt a Debit that's guaranteed to fail (or
+    # risk an unauthenticated charge by dropping the 3DS fields).
+    if not three_ds_auth.get('CardHolderAuthenticationData'):
+        logger.warning(
+            "3DS ReturnUrl: no CardHolderAuthenticationData (card not 3DS-enrolled) "
+            "— declining without attempting the Debit | ref=%s enrolled=%s",
+            merchant_ref, three_ds_auth.get('ThreeDSecure_VEResEnrolled'),
+        )
+        stored.pop('_signed_card', None)
+        txn.gateway_response = stored
+        txn.status = CBZTransaction.TransactionStatus.DECLINED
+        txn.result_description = 'Card is not enrolled in 3D Secure. Please try a different card.'
+        txn.save(update_fields=['status', 'result_description', 'gateway_response'])
+        return _redirect(
+            f'/booking/payment-status?channel=card&ref={merchant_ref}&error=3ds_not_enrolled'
+        )
+
     txn.save(update_fields=['gateway_response'])
 
     # Retrieve the temporarily signed card data and complete the Debit

--- a/whatsappcrm_backend/cbz_integration/views.py
+++ b/whatsappcrm_backend/cbz_integration/views.py
@@ -1886,8 +1886,9 @@ def cbz_card_3ds_return_view(request: HttpRequest) -> HttpResponseRedirect:
         stored.pop('_signed_card', None)
         txn.gateway_response = stored
         txn.status = CBZTransaction.TransactionStatus.DECLINED
+        txn.result_code = '255'
         txn.result_description = 'Card is not enrolled in 3D Secure. Please try a different card.'
-        txn.save(update_fields=['status', 'result_description', 'gateway_response'])
+        txn.save(update_fields=['status', 'result_code', 'result_description', 'gateway_response'])
         return _redirect(
             f'/booking/payment-status?channel=card&ref={merchant_ref}&error=3ds_not_enrolled'
         )


### PR DESCRIPTION
## Summary
Follow-up to #98. That PR fixed the `-255 "ElectronicCommerceIndicator ThreeDSecure or ThreeDSecureAttempted required"` error, but production logs then showed a new `-255` rejection for the same not-3DS-enrolled-card scenario:

```
'Result': {'Status': '-1', 'Code': '255', 'Description': 'Missing CardHolderAuthenticationData', 'Source': 'EMPTranzWareCBZZimbabweTestProvider', ...}
```

iVeri's Debit hard-requires `CardHolderAuthenticationData` whenever any 3DS ECI (`ThreeDSecure` or `ThreeDSecureAttempted`) is sent. Cards that aren't 3DS-enrolled never get this field back from iVeri's ACS/enrollment step — confirmed by the `3DS ReturnUrl received | keys=[...]` log, which never includes `CardHolderAuthenticationData` for these cards. So the `ThreeDSecureAttempted` fallback from #98 still fails, just with a different `-255` message.

There's no valid substitute value to send in place of the missing field, so `cbz_card_3ds_return_view` now declines the transaction locally (status `DECLINED`, message "Card is not enrolled in 3D Secure. Please try a different card.") before attempting the Debit, instead of making a gateway call that's guaranteed to fail or dropping 3DS entirely and risking an unauthenticated charge.

## Test plan
- [x] Added `test_3ds_return_declines_when_no_cardholder_auth_data` in `cbz_integration/tests.py` — asserts the transaction is marked `DECLINED`, the redirect carries `error=3ds_not_enrolled`, and `debit_card()` is never called.
- [x] Ran `python manage.py test cbz_integration` (sqlite) — all card/3DS/payload tests pass (12/12 in the relevant test classes); pre-existing failures are unrelated Redis/Celery signal tests that fail identically on `main` in this sandbox (no Redis available).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Br2w1M162izdtiXtSfCqfX)_