### PR TITLE
Fix Paynow result_url + fall back to non-3DS debit for unverifiable 3DS enrollment

### DIFF
--- a/whatsappcrm_backend/cbz_integration/tests.py
+++ b/whatsappcrm_backend/cbz_integration/tests.py
@@ -7,6 +7,7 @@ from decimal import Decimal
 from unittest.mock import patch, MagicMock
 
 from django.contrib.admin.sites import AdminSite
+from django.core import signing
 from django.test import TestCase, RequestFactory
 from django.utils import timezone
 
@@ -24,6 +25,7 @@ from .views import (
     cbz_card_3ds_return_view,
     cbz_certificate_generate_view,
     cbz_certificate_renew_view,
+    _3DS_PAN_SALT,
 )
 from .constants import (
     ECOCASH_PAN_PREFIX, ECOCASH_DEFAULT_EXPIRY,
@@ -860,6 +862,50 @@ class CBZCard3DSViewTests(TestCase):
         self.assertEqual(txn.status, CBZTransaction.TransactionStatus.DECLINED)
         self.assertEqual(txn.result_code, '255')
         mock_client.debit_card.assert_not_called()
+
+    @patch('cbz_integration.views._build_client')
+    def test_3ds_return_proceeds_without_3ds_when_enrollment_unable_to_verify(self, mock_build_client):
+        """When iVeri reports ThreeDSecure_VEResEnrolled='U' (unable to verify,
+        as opposed to a confirmed 'N'), business decision is to proceed with a
+        plain non-3DS Debit rather than decline outright."""
+        mock_client = MagicMock()
+        mock_client.debit_card.return_value = {'Transaction': {'ResultCode': '0', 'Status': 'Approved'}}
+        mock_build_client.return_value = mock_client
+
+        signed_card = signing.dumps(
+            {'pan': '4070427646039018', 'expiry': '1230', 'cvv': '123'},
+            salt=_3DS_PAN_SALT,
+        )
+        txn = CBZTransaction.objects.create(
+            merchant_reference='KS-3DS-UNABLE-TO-VERIFY',
+            payment_type=CBZTransaction.PaymentType.CARD,
+            masked_pan='4070****9018',
+            amount=Decimal('25.00'),
+            currency='USD',
+            command='Debit',
+            status=CBZTransaction.TransactionStatus.PENDING,
+            gateway_response={'_signed_card': signed_card},
+        )
+
+        request = self.factory.post(
+            '/crm-api/payments/cbz/card/3ds/return/',
+            data={
+                'MerchantReference': txn.merchant_reference,
+                'ResultCode': '0',
+                'ElectronicCommerceIndicator': '07',
+                'ThreeDSecure_VEResEnrolled': 'U',
+                'ThreeDSecure_RequestID': 'REQ-2',
+            },
+        )
+
+        response = cbz_card_3ds_return_view(request)
+        txn.refresh_from_db()
+
+        self.assertEqual(response.status_code, 302)
+        self.assertNotIn('error=3ds_not_enrolled', response.url)
+        mock_client.debit_card.assert_called_once()
+        self.assertIsNone(mock_client.debit_card.call_args.kwargs['threed_secure_data'])
+        self.assertEqual(txn.status, CBZTransaction.TransactionStatus.APPROVED)
 
 
 class IVeriCertificateClientTests(TestCase):

--- a/whatsappcrm_backend/cbz_integration/views.py
+++ b/whatsappcrm_backend/cbz_integration/views.py
@@ -1874,24 +1874,37 @@ def cbz_card_3ds_return_view(request: HttpRequest) -> HttpResponseRedirect:
     # iVeri's Debit hard-requires CardHolderAuthenticationData whenever a 3DS
     # ECI is sent. Cards that aren't 3DS-enrolled never get this field from
     # the ACS/enrollment step, and iVeri rejects the Debit with -255 "Missing
-    # CardHolderAuthenticationData" — there's no valid substitute value, so
-    # decline here rather than attempt a Debit that's guaranteed to fail (or
-    # risk an unauthenticated charge by dropping the 3DS fields).
+    # CardHolderAuthenticationData" — there's no valid substitute value.
+    proceed_without_3ds = False
     if not three_ds_auth.get('CardHolderAuthenticationData'):
-        logger.warning(
-            "3DS ReturnUrl: no CardHolderAuthenticationData (card not 3DS-enrolled) "
-            "— declining without attempting the Debit | ref=%s enrolled=%s",
-            merchant_ref, three_ds_auth.get('ThreeDSecure_VEResEnrolled'),
-        )
-        stored.pop('_signed_card', None)
-        txn.gateway_response = stored
-        txn.status = CBZTransaction.TransactionStatus.DECLINED
-        txn.result_code = '255'
-        txn.result_description = 'Card is not enrolled in 3D Secure. Please try a different card.'
-        txn.save(update_fields=['status', 'result_code', 'result_description', 'gateway_response'])
-        return _redirect(
-            f'/booking/payment-status?channel=card&ref={merchant_ref}&error=3ds_not_enrolled'
-        )
+        enrolled = str(three_ds_auth.get('ThreeDSecure_VEResEnrolled') or '').strip().upper()
+        if enrolled == 'U':
+            # iVeri couldn't determine enrollment at all (as opposed to a
+            # confirmed "not enrolled"). Business decision: proceed with a
+            # plain non-3DS Debit rather than declining outright. This shifts
+            # fraud/chargeback liability for these transactions onto the
+            # merchant, since there's no 3DS or "attempts" liability shift.
+            proceed_without_3ds = True
+            logger.warning(
+                "3DS ReturnUrl: enrollment status 'U' (unable to verify) — "
+                "proceeding with a plain non-3DS Debit | ref=%s",
+                merchant_ref,
+            )
+        else:
+            logger.warning(
+                "3DS ReturnUrl: no CardHolderAuthenticationData (card not 3DS-enrolled) "
+                "— declining without attempting the Debit | ref=%s enrolled=%s",
+                merchant_ref, enrolled,
+            )
+            stored.pop('_signed_card', None)
+            txn.gateway_response = stored
+            txn.status = CBZTransaction.TransactionStatus.DECLINED
+            txn.result_code = '255'
+            txn.result_description = 'Card is not enrolled in 3D Secure. Please try a different card.'
+            txn.save(update_fields=['status', 'result_code', 'result_description', 'gateway_response'])
+            return _redirect(
+                f'/booking/payment-status?channel=card&ref={merchant_ref}&error=3ds_not_enrolled'
+            )
 
     txn.save(update_fields=['gateway_response'])
 
@@ -1933,7 +1946,7 @@ def cbz_card_3ds_return_view(request: HttpRequest) -> HttpResponseRedirect:
             amount=txn.amount,
             currency=txn.currency,
             merchant_reference=merchant_ref,
-            threed_secure_data=three_ds_auth or None,
+            threed_secure_data=None if proceed_without_3ds else (three_ds_auth or None),
         )
 
         result = IVeriClient.get_result(response)

--- a/whatsappcrm_backend/whatsappcrm_backend/settings.py
+++ b/whatsappcrm_backend/whatsappcrm_backend/settings.py
@@ -459,6 +459,13 @@ JAZZMIN_UI_TWEAKS = {
 BACKEND_DOMAIN_FOR_CSP = os.getenv('BACKEND_DOMAIN_FOR_CSP', 'backend.kalaisafaris.com') # Default to Kalai Safaris
 FRONTEND_DOMAIN_FOR_CSP = os.getenv('FRONTEND_DOMAIN_FOR_CSP', 'dashboard.kalaisafaris.com') # Default to Kalai Safaris
 
+# Public base URL of this backend, used by paynow_integration to build the
+# resulturl/returnurl sent to Paynow. Previously unset, so PaynowService's
+# `getattr(settings, 'SITE_URL', ...)` always fell through to a placeholder
+# ('https://your-domain.com') that doesn't resolve, regardless of any
+# SITE_URL value in .env.
+SITE_URL = os.getenv('SITE_URL', f'https://{BACKEND_DOMAIN_FOR_CSP}')
+
 # Base directives for production
 connect_src_list = [
     "'self'",


### PR DESCRIPTION
## Summary

**1. Wire `SITE_URL` into settings so Paynow gets a real result_url**
- `paynow_integration/services.py` builds Paynow's `resulturl`/`returnurl` via `getattr(settings, 'SITE_URL', 'https://your-domain.com')`.
- `SITE_URL` was never assigned as a name anywhere in `settings.py`. Django's `settings` object only exposes attributes actually assigned at module level — env vars in `.env`/`.env.prod` do nothing unless `settings.py` reads them into a name. So the `getattr` always fell through to the literal placeholder `'https://your-domain.com'`, a domain that doesn't resolve, regardless of what (if anything) was set for `SITE_URL` in the environment.
- Added `SITE_URL = os.getenv('SITE_URL', f'https://{BACKEND_DOMAIN_FOR_CSP}')` in `settings.py`, following the same pattern already used for `BACKEND_DOMAIN_FOR_CSP`/`FRONTEND_DOMAIN_FOR_CSP`.

**2. Fall back to non-3DS debit when iVeri can't verify 3DS enrollment**
- Follow-up to #99. That PR declined all cards where iVeri's `/3ds/return/` callback gave no `CardHolderAuthenticationData` (both `ThreeDSecure_VEResEnrolled='N'` and `='U'`).
- Per business decision, cards where iVeri returns `'U'` (unable to verify enrollment at all, as opposed to a confirmed `'N'`) now proceed with a plain Debit (no ECI/3DS fields), accepting the fraud/chargeback liability tradeoff for that narrower case. Confirmed `'N'` cards still decline exactly as before.

## Test plan
- [x] Verified via `django.setup()` that `settings.SITE_URL` now resolves to `https://backend.kalaisafaris.com` with no `SITE_URL` env var set.
- [x] Added `test_3ds_return_proceeds_without_3ds_when_enrollment_unable_to_verify` — asserts `debit_card()` is called with `threed_secure_data=None` and the transaction is approved when the mocked gateway approves it.
- [x] Existing `test_3ds_return_declines_when_no_cardholder_auth_data` (enrolled='N') still passes unchanged — confirms the decline path is untouched for confirmed-not-enrolled cards.
- [x] Ran `python manage.py test cbz_integration` (sqlite) — all card/3DS/payload tests pass; pre-existing failures are unrelated Redis/Celery signal tests that fail identically on `main` in this sandbox (no Redis available).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
