### PR TITLE
Fix COPYandPAY testMode leaking into LIVE transactions

### DIFF
--- a/whatsappcrm_backend/cbz_integration/views.py
+++ b/whatsappcrm_backend/cbz_integration/views.py
@@ -160,14 +160,19 @@ def _get_copyandpay_config() -> Dict[str, str]:
             or getattr(settings, 'COPYANDPAY_BEARER_TOKEN', '')
             or os.getenv('COPYANDPAY_BEARER_TOKEN', '')
         ).strip(),
+        # NOTE: testMode must never be sent on LIVE — OPPWA rejects live
+        # transactions with "test mode not allowed" if it's present. Gate the
+        # whole lookup on `mode == 'Test'` so a leftover COPYANDPAY_TEST_MODE
+        # env var (e.g. EXTERNAL, set for UAT) can't leak into production
+        # just because the DB config field is blank.
         'test_mode': (
             (
                 (getattr(config, 'copyandpay_test_mode', '') if config else '')
                 or getattr(settings, 'COPYANDPAY_TEST_MODE', '')
                 or os.getenv('COPYANDPAY_TEST_MODE', '')
             ).strip()
-            or ('EXTERNAL' if mode == 'Test' else '')
-        ),
+            or 'EXTERNAL'
+        ) if mode == 'Test' else '',
         'brands': (
             (getattr(config, 'copyandpay_brands', '') if config else '')
             or getattr(settings, 'COPYANDPAY_BRANDS', '')


### PR DESCRIPTION
## Summary

- Fixes `_get_copyandpay_config()` in `whatsappcrm_backend/cbz_integration/views.py` so `testMode` is never sent to OPPWA once `CBZConfig.mode` is switched to `LIVE`.
- Root cause: the old resolution order was `DB config field → Django setting → env var → default`, with no check on `mode` until the very end. If the deployment environment still had `COPYANDPAY_TEST_MODE=EXTERNAL` set (as recommended for UAT in `.env.example`) and the DB config's `copyandpay_test_mode` field was left blank, that env var kept winning even after flipping the config to `LIVE`, so `testMode: EXTERNAL` was still sent to the live endpoint — which OPPWA rejects with "test mode not allowed".
- Fix: the entire `test_mode` lookup (config field → setting → env var → `EXTERNAL` default) is now only evaluated `if mode == 'Test'`; in `LIVE` mode `test_mode` is always `''`, so no `testMode` key is ever added to the checkout request regardless of leftover env/settings values.

This same helper is used by both the public-website card checkout flow (`cbz_integration/views.py`) and the WhatsApp ZimSwitch payment flow (`omari_integration/flow_actions.py` imports `_get_copyandpay_config` from `views.py`), so both are fixed by this one change.

## Test plan

- [x] `python3 -m ast` sanity check that `views.py` still parses.
- [ ] In the deployed environment: confirm `CBZConfig.mode = LIVE` with production entityId/bearer token now completes a real COPYandPAY checkout without an OPPWA "test mode not allowed" error, even with `COPYANDPAY_TEST_MODE=EXTERNAL` still set in the environment.


---
_Generated by [Claude Code](https://claude.ai/code/session_017MxapusjXoJTLL2zdBoECF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured live payment transactions no longer receive test-mode values.
  * Test-mode settings are now applied only when the payment gateway is configured for testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->