### PR TITLE
Show ZimSwitch instead of COPYandPAY in customer-facing card payment UI

### DIFF
--- a/public-website/src/app/booking/payment-status/page.tsx
+++ b/public-website/src/app/booking/payment-status/page.tsx
@@ -208,7 +208,7 @@ function PaymentStatusPageContent() {
         setStatus('approved');
         setMessage(
           result.gateway_mode === 'Test'
-            ? `Sandbox approval only. ${cardProvider === 'copyandpay' ? 'COPYandPAY' : 'iVeri'} is in Test mode, so no real customer charge was made. Reference: ${result.merchant_reference || reference}`
+            ? `Sandbox approval only. ${cardProvider === 'copyandpay' ? 'ZimSwitch' : 'iVeri'} is in Test mode, so no real customer charge was made. Reference: ${result.merchant_reference || reference}`
             : (result.message || `Payment approved. Reference: ${result.merchant_reference || reference}`)
         );
         window.sessionStorage.removeItem(PENDING_3DS_REF_KEY);
@@ -324,7 +324,7 @@ function PaymentStatusPageContent() {
 
         {gatewayMode === 'Test' && (
           <div className="mb-4 rounded-2xl border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-900">
-            This transaction was processed against the {cardProvider === 'copyandpay' ? 'COPYandPAY' : 'iVeri'} sandbox. Use live gateway credentials before treating approvals as real payments.
+            This transaction was processed against the {cardProvider === 'copyandpay' ? 'ZimSwitch' : 'iVeri'} sandbox. Use live gateway credentials before treating approvals as real payments.
           </div>
         )}
 

--- a/public-website/src/components/BookingModal.tsx
+++ b/public-website/src/components/BookingModal.tsx
@@ -1053,11 +1053,11 @@ export default function BookingModal({
 
   const submitCardPayment = async () => {
     if (cardProvider === 'copyandpay' && !isCopyAndPayAvailable) {
-      setPaymentMessage('COPYandPAY is not configured at the moment. Please use CBZ Direct Card.');
+      setPaymentMessage('ZimSwitch is not configured at the moment. Please use CBZ Direct Card.');
       return;
     }
     if (cardProvider === 'cbz_direct' && !isCbzDirectAvailable) {
-      setPaymentMessage('CBZ Direct Card is not configured at the moment. Please use COPYandPAY.');
+      setPaymentMessage('CBZ Direct Card is not configured at the moment. Please use ZimSwitch.');
       return;
     }
 
@@ -1475,7 +1475,7 @@ export default function BookingModal({
                             onClick={() => setCardProvider('copyandpay')}
                             className={`rounded-lg py-2 text-xs font-semibold transition ${cardProvider === 'copyandpay' ? 'bg-white shadow text-gray-900' : 'text-gray-600'}`}
                           >
-                            COPYandPAY (Hosted)
+                            ZimSwitch (Hosted)
                           </button>
                         )}
                         {isCbzDirectAvailable && (
@@ -1504,7 +1504,7 @@ export default function BookingModal({
                     </div>
                     {cardProvider === 'copyandpay' && (
                       <div className="rounded-xl border border-blue-200 bg-blue-50 p-3 text-sm text-blue-800">
-                        Card details are captured on the next hosted secure page (COPYandPAY). Click <strong>Pay Securely</strong> to continue.
+                        Card details are captured on the next hosted secure ZimSwitch page. Click <strong>Pay Securely</strong> to continue.
                       </div>
                     )}
                     {paymentConfig?.mode === 'Test' && (paymentConfig.card.test_pans ?? []).length > 0 && (
@@ -1649,7 +1649,7 @@ export default function BookingModal({
                         ? 'Continue to Secure Payment'
                         : paymentMode === 'card'
                           ? (cardProvider === 'copyandpay'
-                              ? (isTestMode ? 'Pay with COPYandPAY (Test Mode)' : 'Pay with COPYandPAY')
+                              ? (isTestMode ? 'Pay with ZimSwitch (Test Mode)' : 'Pay with ZimSwitch')
                               : (isTestMode ? 'Pay with CBZ Direct (Test Mode)' : 'Pay with CBZ Direct'))
                           : (isTestMode ? 'Start EcoCash Payment (Test Mode)' : 'Start EcoCash Payment')}
                   </button>


### PR DESCRIPTION
## Summary

- Renames every customer-facing label, button, and status message for the hosted-card payment option from "COPYandPAY" to "ZimSwitch" in `BookingModal.tsx` and `payment-status/page.tsx`: the provider toggle button ("ZimSwitch (Hosted)"), the info banner, the two "not configured" fallback messages, the pay button text, and the sandbox/test-mode status messages.
- COPYandPAY is the OPPWA hosted-widget vendor's product name; ZimSwitch is the acquiring network/brand this merchant account is actually provisioned under and the one Zimbabwean cardholders recognize — so it's the clearer label for end users.
- Left untouched (internal plumbing, not user-facing): the `cardProvider` state's `'copyandpay'` value, `isCopyAndPayAvailable`/`paymentConfig.card.copyandpay` config keys, and the `/crm-api/payments/cbz/copyandpay/...` route segments — all of these are wired to real backend contracts and renaming them would be a much larger, riskier change than what was asked for.

## Test plan

- [x] `npx tsc --noEmit` — passes
- [x] `npm run lint` on the two changed files — no new issues (pre-existing warning on `BookingModal.tsx` untouched)


---
_Generated by [Claude Code](https://claude.ai/code/session_01KT9DfdTbnSeJ6RRa3kZzUG)_