### PR TITLE
Hide the brand selector on the ZimSwitch/OPPWA card checkout widget

### DIFF
--- a/public-website/src/app/booking/card-checkout/page.tsx
+++ b/public-website/src/app/booking/card-checkout/page.tsx
@@ -142,33 +142,14 @@ const WIDGET_CSS = `
     transform: none;
   }
 
-  /* Brand selector row — lets the cardholder explicitly pick their card type
-     (e.g. Private Label) when it can't be auto-detected from the PAN alone. */
+  /* Brand selector — hidden. This merchant entityId is provisioned as
+     PRIVATE_LABEL only (see CBZConfig.copyandpay_brands), so letting the
+     cardholder pick a different brand icon here has nothing to select
+     between and only invites confusion. */
+  .wpwl-group-brand,
+  .wpwl-label-brand,
   .wpwl-wrapper-brand {
-    display: flex;
-    gap: 0.6rem;
-    margin-bottom: 1.25rem;
-    flex-wrap: wrap;
-  }
-  .wpwl-wrapper-brand .wpwl-brand-card {
-    width: 3rem;
-    height: 1.95rem;
-    background: #fff;
-    border: 1.5px solid #e5e7eb;
-    border-radius: 0.5rem;
-    cursor: pointer;
-    opacity: 0.55;
-    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06);
-    transition: opacity 0.15s, border-color 0.15s, box-shadow 0.15s, transform 0.1s;
-  }
-  .wpwl-wrapper-brand .wpwl-brand-card:hover {
-    opacity: 0.85;
-    transform: translateY(-1px);
-  }
-  .wpwl-wrapper-brand .wpwl-brand-card.wpwl-selected-brand {
-    opacity: 1;
-    border-color: #E8600A;
-    box-shadow: 0 0 0 3px rgba(232, 96, 10, 0.15);
+    display: none !important;
   }
 
   /* Validation error messages from widget */


### PR DESCRIPTION
## Summary

- Hides the OPPWA brand-selector row (Visa/Mastercard/Amex/Private Label icons) on the ZimSwitch hosted card checkout form (`booking/card-checkout/page.tsx`).
- This merchant `entityId` is provisioned as `PRIVATE_LABEL` only (`CBZConfig.copyandpay_brands` help text: *"This merchant entityId is provisioned by ZimSwitch as Private Label only"*), so the selector had nothing meaningful to choose between — just confusing UI, and a plausible source of "picked the wrong brand" support/error noise.
- Replaces the now-unused selector styling with a `display: none !important` rule targeting `.wpwl-group-brand`, `.wpwl-label-brand`, and `.wpwl-wrapper-brand`, so it's fully removed from the layout regardless of how many brands the widget happens to render for — no phantom empty space left behind.

## Test plan

- [x] `npx tsc --noEmit` — passes
- [x] `npm run lint` on the changed file — no new issues (pre-existing `react-hooks/set-state-in-effect` finding untouched)
- [x] Verified visually with a static mock of OPPWA's documented DOM structure (same approach used in #105) — the selector row is fully gone with no leftover gap, form flows straight from the header into "Name on Card"


---
_Generated by [Claude Code](https://claude.ai/code/session_01KT9DfdTbnSeJ6RRa3kZzUG)_